### PR TITLE
Sprint 15: Core Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@
 
 [In progress]
 
+* Clean Swift
+* Navigation: Coordinator
+* DI: на базе фабрик
+* Layout: Anchors, CompositionalLayout
+* Fonts: YSDisplay
+
 # Structure
 
 * "App": App и Scene delegates, глобальные объекты приложения: DI, навигация и др.

--- a/YP-Tracker.xcodeproj/project.pbxproj
+++ b/YP-Tracker.xcodeproj/project.pbxproj
@@ -18,9 +18,6 @@
 		5A48061F29DBA73B0096B7D8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A48061E29DBA73B0096B7D8 /* SceneDelegate.swift */; };
 		5A48062629DBA73F0096B7D8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5A48062529DBA73F0096B7D8 /* Assets.xcassets */; };
 		5A48062929DBA73F0096B7D8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A48062729DBA73F0096B7D8 /* LaunchScreen.storyboard */; };
-		5A48063329DBABAA0096B7D8 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 5A48063229DBABAA0096B7D8 /* README.md */; };
-		5A48063529DBAC2C0096B7D8 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 5A48063429DBAC2C0096B7D8 /* .swiftlint.yml */; };
-		5A48063729DBAC450096B7D8 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 5A48063629DBAC450096B7D8 /* .gitignore */; };
 		5A48063A29DBC5690096B7D8 /* Theme+Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A48063929DBC5690096B7D8 /* Theme+Fonts.swift */; };
 		5A48064229DBCB8D0096B7D8 /* Swift_BaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A48064129DBCB8D0096B7D8 /* Swift_BaseTests.swift */; };
 		5A48064F29DBCBFB0096B7D8 /* Swift_BaseUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A48064E29DBCBFB0096B7D8 /* Swift_BaseUITests.swift */; };
@@ -644,9 +641,6 @@
 			files = (
 				5ADD1F0629E358F50072EE78 /* YSDisplay-Medium.ttf in Resources */,
 				5ADD1F0429E358F50072EE78 /* YSDisplay-Regular.ttf in Resources */,
-				5A48063729DBAC450096B7D8 /* .gitignore in Resources */,
-				5A48063529DBAC2C0096B7D8 /* .swiftlint.yml in Resources */,
-				5A48063329DBABAA0096B7D8 /* README.md in Resources */,
 				5A48062929DBA73F0096B7D8 /* LaunchScreen.storyboard in Resources */,
 				5ADD1F0529E358F50072EE78 /* YSDisplay-Bold.ttf in Resources */,
 				5A48062629DBA73F0096B7D8 /* Assets.xcassets in Resources */,

--- a/YP-Tracker.xcodeproj/project.pbxproj
+++ b/YP-Tracker.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A1DFF012A3B847200AD63F3 /* TrackerCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFEFB2A3B847200AD63F3 /* TrackerCD.swift */; };
+		5A1DFF022A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFEFC2A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift */; };
+		5A1DFF032A3B847200AD63F3 /* TrackerCategoryCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFEFD2A3B847200AD63F3 /* TrackerCategoryCD.swift */; };
+		5A1DFF042A3B847200AD63F3 /* TrackerCategoryCD+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFEFE2A3B847200AD63F3 /* TrackerCategoryCD+CoreDataProperties.swift */; };
+		5A1DFF052A3B847200AD63F3 /* TrackerRecordCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFEFF2A3B847200AD63F3 /* TrackerRecordCD.swift */; };
+		5A1DFF062A3B847200AD63F3 /* TrackerRecordCD+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFF002A3B847200AD63F3 /* TrackerRecordCD+CoreDataProperties.swift */; };
+		5A1DFF092A3BB9FB00AD63F3 /* CategoriesManagerCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DFF082A3BB9FB00AD63F3 /* CategoriesManagerCD.swift */; };
 		5A45EA5D2A0CD9BC003269D3 /* StatisticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A45EA5C2A0CD9BC003269D3 /* StatisticsViewController.swift */; };
 		5A45EA602A0CE96D003269D3 /* TrackersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A45EA5F2A0CE96D003269D3 /* TrackersViewController.swift */; };
 		5A45EA672A0D22CE003269D3 /* EmptyInputData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A45EA632A0D22CE003269D3 /* EmptyInputData.swift */; };
@@ -83,6 +90,9 @@
 		5AF5CAF42A124EA4004AB8D2 /* CategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5CAF32A124EA4004AB8D2 /* CategoriesProvider.swift */; };
 		5AF5CAF62A125333004AB8D2 /* CategoriesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5CAF52A125333004AB8D2 /* CategoriesManager.swift */; };
 		5AF5CAF92A12D0A4004AB8D2 /* TrackerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5CAF82A12D0A4004AB8D2 /* TrackerFilter.swift */; };
+		5AFC98AA2A32FD39005E3C4D /* CoreDataTrainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC98A92A32FD39005E3C4D /* CoreDataTrainerViewController.swift */; };
+		5AFC98B52A366735005E3C4D /* TrackersMOC.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC98B32A366735005E3C4D /* TrackersMOC.xcdatamodeld */; };
+		5AFC98B72A37CB1E005E3C4D /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFC98B62A37CB1E005E3C4D /* CoreDataStack.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,6 +113,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5A1DFEFB2A3B847200AD63F3 /* TrackerCD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCD.swift; sourceTree = "<group>"; };
+		5A1DFEFC2A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TrackerCD+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		5A1DFEFD2A3B847200AD63F3 /* TrackerCategoryCD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerCategoryCD.swift; sourceTree = "<group>"; };
+		5A1DFEFE2A3B847200AD63F3 /* TrackerCategoryCD+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TrackerCategoryCD+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		5A1DFEFF2A3B847200AD63F3 /* TrackerRecordCD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRecordCD.swift; sourceTree = "<group>"; };
+		5A1DFF002A3B847200AD63F3 /* TrackerRecordCD+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TrackerRecordCD+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		5A1DFF082A3BB9FB00AD63F3 /* CategoriesManagerCD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesManagerCD.swift; sourceTree = "<group>"; };
 		5A45EA5C2A0CD9BC003269D3 /* StatisticsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewController.swift; sourceTree = "<group>"; };
 		5A45EA5F2A0CE96D003269D3 /* TrackersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackersViewController.swift; sourceTree = "<group>"; };
 		5A45EA632A0D22CE003269D3 /* EmptyInputData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyInputData.swift; sourceTree = "<group>"; };
@@ -186,6 +203,9 @@
 		5AF5CAF32A124EA4004AB8D2 /* CategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesProvider.swift; sourceTree = "<group>"; };
 		5AF5CAF52A125333004AB8D2 /* CategoriesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesManager.swift; sourceTree = "<group>"; };
 		5AF5CAF82A12D0A4004AB8D2 /* TrackerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerFilter.swift; sourceTree = "<group>"; };
+		5AFC98A92A32FD39005E3C4D /* CoreDataTrainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTrainerViewController.swift; sourceTree = "<group>"; };
+		5AFC98B42A366735005E3C4D /* TrackersMOC.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TrackersMOC.xcdatamodel; sourceTree = "<group>"; };
+		5AFC98B62A37CB1E005E3C4D /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +233,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5A1DFF072A3B860A00AD63F3 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				5A1DFEFB2A3B847200AD63F3 /* TrackerCD.swift */,
+				5A1DFEFC2A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift */,
+				5A1DFEFD2A3B847200AD63F3 /* TrackerCategoryCD.swift */,
+				5A1DFEFE2A3B847200AD63F3 /* TrackerCategoryCD+CoreDataProperties.swift */,
+				5A1DFEFF2A3B847200AD63F3 /* TrackerRecordCD.swift */,
+				5A1DFF002A3B847200AD63F3 /* TrackerRecordCD+CoreDataProperties.swift */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
+		5A1DFF0C2A3C3C7F00AD63F3 /* Trainer */ = {
+			isa = PBXGroup;
+			children = (
+				5AFC98A92A32FD39005E3C4D /* CoreDataTrainerViewController.swift */,
+			);
+			path = Trainer;
+			sourceTree = "<group>";
+		};
 		5A45EA5E2A0CE7AB003269D3 /* Statistics */ = {
 			isa = PBXGroup;
 			children = (
@@ -326,6 +367,8 @@
 				5A8D1DB12A0DAFAB00A2924F /* TrackerColor.swift */,
 				5AF5CAF82A12D0A4004AB8D2 /* TrackerFilter.swift */,
 				5AE6BDF42A19D8770068CB53 /* TrackerConditions.swift */,
+				5A1DFF072A3B860A00AD63F3 /* CoreData */,
+				5AFC98B32A366735005E3C4D /* TrackersMOC.xcdatamodeld */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -347,6 +390,7 @@
 		5A65415629DE1A470042503D /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				5A1DFF0C2A3C3C7F00AD63F3 /* Trainer */,
 				5AA5FA292A13CDCC0056633B /* Protocols */,
 				5AE1F0082A0944D400103F08 /* Coordinator+Router */,
 				5A45EA622A0D22CE003269D3 /* OptionalViews */,
@@ -529,7 +573,9 @@
 			children = (
 				5AF5CAF12A12385F004AB8D2 /* Repository.swift */,
 				5AF5CAF52A125333004AB8D2 /* CategoriesManager.swift */,
+				5A1DFF082A3BB9FB00AD63F3 /* CategoriesManagerCD.swift */,
 				5AF5CAF32A124EA4004AB8D2 /* CategoriesProvider.swift */,
+				5AFC98B62A37CB1E005E3C4D /* CoreDataStack.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -697,6 +743,7 @@
 				5A84742D2A0E9A7500C2F93E /* CreateEditTrackerViewController.swift in Sources */,
 				5A8CD5202A20057B00A100BD /* InnerViewType.swift in Sources */,
 				5AE6BDE92A18D38F0068CB53 /* YPCell.swift in Sources */,
+				5A1DFF012A3B847200AD63F3 /* TrackerCD.swift in Sources */,
 				5A45EA602A0CE96D003269D3 /* TrackersViewController.swift in Sources */,
 				5AE12A202A0A6B360054D782 /* AppCoordinator.swift in Sources */,
 				5AF5CAF62A125333004AB8D2 /* CategoriesManager.swift in Sources */,
@@ -705,6 +752,7 @@
 				5A45EA5D2A0CD9BC003269D3 /* StatisticsViewController.swift in Sources */,
 				5ADD1F0929E38E6E0072EE78 /* UIColor+Hex.swift in Sources */,
 				5A8D1DB52A0DAFAB00A2924F /* TrackerCategory.swift in Sources */,
+				5A1DFF052A3B847200AD63F3 /* TrackerRecordCD.swift in Sources */,
 				5AA7AD0A2A163A990022C334 /* TrackersModels.swift in Sources */,
 				5AE1F0172A0948A500103F08 /* Di+ServiceFactory.swift in Sources */,
 				5AA5FA2F2A13CE4F0056633B /* UITableView+Extensions.swift in Sources */,
@@ -720,19 +768,25 @@
 				5ADD1F0A29E38E6E0072EE78 /* UIColor+Dynamic.swift in Sources */,
 				5AE12A3B2A0BE8CF0054D782 /* TabbarViewController.swift in Sources */,
 				5AF5CAF92A12D0A4004AB8D2 /* TrackerFilter.swift in Sources */,
+				5AFC98B52A366735005E3C4D /* TrackersMOC.xcdatamodeld in Sources */,
 				5AE1F0192A0948B100103F08 /* Di+ModuleFactory.swift in Sources */,
+				5A1DFF062A3B847200AD63F3 /* TrackerRecordCD+CoreDataProperties.swift in Sources */,
 				5A4668A32A1AA65F00FEBD9B /* CreateEditTrackerPresenter.swift in Sources */,
 				5AE1F00E2A0944D400103F08 /* Router.swift in Sources */,
+				5A1DFF042A3B847200AD63F3 /* TrackerCategoryCD+CoreDataProperties.swift in Sources */,
 				5AE12A2D2A0B93B70054D782 /* Theme+Constants.swift in Sources */,
 				5A91DED829E0DF58001A23C3 /* UIView+Constraints.swift in Sources */,
 				5AE6BDE72A18187A0068CB53 /* CellCorner.swift in Sources */,
+				5AFC98AA2A32FD39005E3C4D /* CoreDataTrainerViewController.swift in Sources */,
 				5AA5FA2E2A13CE4F0056633B /* UICollectionView+Extensions.swift in Sources */,
 				5AA5FA382A1439CE0056633B /* TrackerCell.swift in Sources */,
+				5A1DFF032A3B847200AD63F3 /* TrackerCategoryCD.swift in Sources */,
 				5AA5FA322A1409420056633B /* TrackerColorCell.swift in Sources */,
 				5AE12A252A0B90390054D782 /* Theme+Colors.swift in Sources */,
 				5AF5CAF42A124EA4004AB8D2 /* CategoriesProvider.swift in Sources */,
 				5A45EA672A0D22CE003269D3 /* EmptyInputData.swift in Sources */,
 				5AF5CAF22A12385F004AB8D2 /* Repository.swift in Sources */,
+				5A1DFF092A3BB9FB00AD63F3 /* CategoriesManagerCD.swift in Sources */,
 				5A8D1DB72A0DAFAB00A2924F /* TrackerRecord.swift in Sources */,
 				5AA7AD0E2A1648E20022C334 /* TrackersPresenter.swift in Sources */,
 				5A8D1DB62A0DAFAB00A2924F /* TrackerColor.swift in Sources */,
@@ -745,6 +799,7 @@
 				5A91DEDA29E12F82001A23C3 /* UIViewController+Preview.swift in Sources */,
 				5AA7AD102A16AA590022C334 /* HeaderSupplementaryView.swift in Sources */,
 				5AE12A322A0BC70F0054D782 /* TrackersCoordinator.swift in Sources */,
+				5A1DFF022A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift in Sources */,
 				5A84742B2A0E91BC00C2F93E /* CreateEditTrackerCoordinator.swift in Sources */,
 				5AE1F00C2A0944D400103F08 /* IRouter.swift in Sources */,
 				5A46689F2A1AA55300FEBD9B /* CreateEditTrackerModels.swift in Sources */,
@@ -757,6 +812,7 @@
 				5A48061F29DBA73B0096B7D8 /* SceneDelegate.swift in Sources */,
 				5AE1F00D2A0944D400103F08 /* ICoordinator.swift in Sources */,
 				5AE12A292A0B931F0054D782 /* Theme+Sizes+Spacing.swift in Sources */,
+				5AFC98B72A37CB1E005E3C4D /* CoreDataStack.swift in Sources */,
 				5A8D1DB42A0DAFAB00A2924F /* Tracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1089,6 +1145,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		5AFC98B32A366735005E3C4D /* TrackersMOC.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				5AFC98B42A366735005E3C4D /* TrackersMOC.xcdatamodel */,
+			);
+			currentVersion = 5AFC98B42A366735005E3C4D /* TrackersMOC.xcdatamodel */;
+			path = TrackersMOC.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 5A48061129DBA73B0096B7D8 /* Project object */;
 }

--- a/YP-Tracker/App/Di/Di+ModuleFactory.swift
+++ b/YP-Tracker/App/Di/Di+ModuleFactory.swift
@@ -11,11 +11,16 @@ protocol IModuleFactory: AnyObject {
 	func makeSelectTypeTrackerModule() -> (UIViewController, ISelectTypeTrackerInteractor)
 	func makeYPModule(trackerAction: Tracker.Action) -> (UIViewController, IYPInteractor)
 	func makeCreateEditTrackerModule(trackerAction: Tracker.Action) -> (UIViewController, ICreateEditTrackerInteractor)
+	func makeCoreDataTrainerModule() -> UIViewController
 }
 
 extension Di {
 	func makeOnboardingModule(dep: AllDependencies) -> UIViewController {
 		return OnboardingViewController()
+	}
+
+	func makeCoreDataTrainerModule(dep: AllDependencies) -> UIViewController {
+		return CoreDataTrainerViewController()
 	}
 
 	func makeTabbarModule(dep: AllDependencies) -> UIViewController {

--- a/YP-Tracker/App/Di/Di+ServiceFactory.swift
+++ b/YP-Tracker/App/Di/Di+ServiceFactory.swift
@@ -4,6 +4,7 @@ import Foundation
 
 protocol IServiceFactory {
 	func makeCategoriesManager(repository: ICategoriesRepository) -> ICategoriesManager
+	func makeCategoriesManager(dataStore: ITrackersDataStore) -> ICategoriesManager
 	func makeCategoriesProvider(manager: ICategoriesManager) -> ICategoriesProvider
 }
 
@@ -14,6 +15,10 @@ extension Di: IServiceFactory {
 			categories: repository.getCategories(),
 			completedTrackers: repository.getCompletedTrackers()
 		)
+	}
+
+	func makeCategoriesManager(dataStore: ITrackersDataStore) -> ICategoriesManager {
+		return CategoriesManagerCD(persistentContainer: dataStore.persistentContainer)
 	}
 
 	func makeCategoriesProvider(manager: ICategoriesManager) -> ICategoriesProvider {

--- a/YP-Tracker/App/Di/Di.swift
+++ b/YP-Tracker/App/Di/Di.swift
@@ -1,7 +1,10 @@
 import UIKit
 final class Di {
 	// MARK: - глобальные сервисы-зависимости
-	private let repository = TrackerCategoriesStub() // по идее извне
+	// по идее должны приходить извне
+	private let repository = TrackerCategoriesStub()
+	// пока не знаю что лучше передавать в инит di сам стек или только имя модели
+	private let trackersDataStore = CoreDataStack(modelName: "TrackersMOC")
 
 	private var dependencies: AllDependencies! // swiftlint:disable:this implicitly_unwrapped_optional
 
@@ -9,7 +12,10 @@ final class Di {
 
 	init() {
 		// MARK: - инициализация глобальных сервисов
-		let categoriesManager = makeCategoriesManager(repository: repository)
+		// вариант для работы в ОП
+		// let categoriesManager = makeCategoriesManager(repository: repository)
+		// вариант для работы с постоянным хранилищем
+		let categoriesManager = makeCategoriesManager(dataStore: trackersDataStore)
 
 		// MARK: - подготовка локальных сервисов
 		dependencies = Dependency(
@@ -54,8 +60,11 @@ extension Di: IModuleFactory {
 		// Вспомогательный метод, для отдельного запуска сцен
 		// при let isOnlyScene = true в SceneDelegate
 
+		var view = makeCoreDataTrainerModule()
+		return view
+
 		// модуль создания трекера
-		var (view, _) = makeCreateEditTrackerModule(trackerAction: .new(.habit))
+		(view, _) = makeCreateEditTrackerModule(trackerAction: .new(.habit))
 		return UINavigationController(rootViewController: view)
 
 		// модуль выбора категории, нужен сервис, кнопка - Добавить категорию
@@ -99,5 +108,8 @@ extension Di: IModuleFactory {
 	}
 	func makeCreateEditTrackerModule(trackerAction: Tracker.Action) -> (UIViewController, ICreateEditTrackerInteractor) {
 		makeCreateEditTrackerModule(dep: dependencies, trackerAction: trackerAction)
+	}
+	func makeCoreDataTrainerModule() -> UIViewController {
+		makeCoreDataTrainerModule(dep: dependencies)
 	}
 }

--- a/YP-Tracker/App/Services/CategoriesManagerCD.swift
+++ b/YP-Tracker/App/Services/CategoriesManagerCD.swift
@@ -1,0 +1,281 @@
+import Foundation
+import CoreData
+
+final class CategoriesManagerCD {
+	private let persistentContainer: NSPersistentContainer
+
+	private var mainContext: NSManagedObjectContext {
+		persistentContainer.viewContext
+	}
+
+	private var backgroundContext: NSManagedObjectContext {
+		let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+		context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+		context.parent = self.mainContext
+		return context
+	}
+
+	init(persistentContainer: NSPersistentContainer) {
+		self.persistentContainer = persistentContainer
+	}
+}
+
+private extension CategoriesManagerCD {
+	func runRequest<T: NSManagedObject>(
+		_ request: NSFetchRequest<T>
+	) -> [T] {
+		var result: [T] = []
+		do {
+			result = try mainContext.fetch(request)
+		} catch let error as NSError {
+			let message = "При выполнении запроса Core Data произошла ошибка:"
+			print(message, error, error.userInfo)
+		}
+		return result
+	}
+
+	func findObjectByUUID<T: NSManagedObject>(
+		id: UUID,
+		key: String,
+		withRequest request: NSFetchRequest<T>
+	) -> T? {
+		request.predicate = NSPredicate(format: "\(key) == %@", id as CVarArg)
+		request.fetchLimit = 1
+		guard let object = runRequest(request).first else { return nil }
+		return object
+	}
+
+	func updateCreateTracker(
+		from tracker: Tracker,
+		withCategoryID categoryID: UUID
+	) {
+		guard let categoryCD = findObjectByUUID(
+			id: categoryID,
+			key: "categoryID",
+			withRequest: TrackerCategoryCD.fetchRequest()
+		) else { return }
+
+		let trackerCD: TrackerCD
+		if let foundTrackerCD = findObjectByUUID(
+			id: tracker.id,
+			key: "trackerID",
+			withRequest: TrackerCD.fetchRequest()
+		) {
+			trackerCD = foundTrackerCD
+		} else {
+			trackerCD = TrackerCD(context: mainContext)
+		}
+
+		trackerCD.trackerID = tracker.id
+		trackerCD.title = tracker.title
+		trackerCD.emoji = tracker.emoji
+		trackerCD.color = tracker.color
+		trackerCD.schedule = tracker.scheduleCD
+		trackerCD.trackerCategory = categoryCD
+		mainContext.saveContext()
+	}
+
+	func completeUncompletedTracker(
+		trackerID: UUID,
+		date: Date
+	) {
+		guard let trackerCD = findObjectByUUID(
+			id: trackerID,
+			key: "trackerID",
+			withRequest: TrackerCD.fetchRequest()
+		) else { return }
+
+		let dateString = Theme.dateFormatterCD.string(from: date)
+
+		let request = TrackerRecordCD.fetchRequest()
+		request.predicate = NSPredicate(
+			format: "trackerID == %@ && dateString == %@",
+			trackerID as CVarArg,
+			dateString
+		)
+
+		if let trackerRecordCD = runRequest(request).first {
+			mainContext.delete(trackerRecordCD)
+		} else {
+			let trackerRecordCD = TrackerRecordCD(context: mainContext)
+			trackerRecordCD.trackerID = trackerID
+			trackerRecordCD.dateString = dateString
+			trackerRecordCD.tracker = trackerCD
+		}
+		mainContext.saveContext()
+	}
+}
+
+// MARK: - ICategoriesManager
+
+extension CategoriesManagerCD: ICategoriesManager {
+	func getCategories() -> [TrackerCategory] {
+		let request = TrackerCategoryCD.fetchRequest()
+		request.sortDescriptors = [
+			NSSortDescriptor(
+				key: "title",
+				ascending: true,
+				selector: #selector(NSString.localizedStandardCompare(_:))
+			)
+		]
+		let objects = runRequest(request)
+		return objects.compactMap { TrackerCategory.convertFromCD(object: $0) }
+	}
+
+	func getTrackers() -> [Tracker] {
+		let request = TrackerCD.fetchRequest()
+		request.sortDescriptors = [
+			NSSortDescriptor(
+				key: "title",
+				ascending: true,
+				selector: #selector(NSString.localizedStandardCompare(_:))
+			)
+		]
+		let objects = runRequest(request)
+		return objects.compactMap { Tracker.convertFromCD(object: $0) }
+	}
+
+	func getCompletedTrackers() -> [TrackerRecord] {
+		let request = TrackerRecordCD.fetchRequest()
+		request.sortDescriptors = [
+			NSSortDescriptor(
+				key: "dateString",
+				ascending: true,
+				selector: #selector(NSString.localizedStandardCompare(_:))
+			)
+		]
+		let objects = runRequest(request)
+		return objects.compactMap { TrackerRecord.convertFromCD(object: $0) }
+	}
+
+	func addCategory(title: String) {
+		// как вариант можно поискать по названию уже имеющуюся
+		// удалить вокруг пробелы и не учитывать регистр
+		// на потом, пока не требуется добавлять
+		let categoryCD = TrackerCategoryCD(context: mainContext)
+		categoryCD.categoryID = UUID()
+		categoryCD.title = title
+		mainContext.saveContext()
+	}
+
+	func editCategoryBy(categoryID: UUID, newtitle: String) {
+		// то же самое что и выше, нельзя допускать одинаковых категорий
+		guard let categoryCD = findObjectByUUID(
+			id: categoryID,
+			key: "categoryID",
+			withRequest: TrackerCategoryCD.fetchRequest()
+		) else { return }
+		categoryCD.title = newtitle
+		mainContext.saveContext()
+	}
+
+	func removeCategoryBy(categoryID: UUID) {
+		guard let categoryCD = findObjectByUUID(
+			id: categoryID,
+			key: "categoryID",
+			withRequest: TrackerCategoryCD.fetchRequest()
+		) else { return }
+		mainContext.delete(categoryCD)
+		mainContext.saveContext()
+	}
+
+	func addTracker(tracker: Tracker, categoryID: UUID) {
+		updateCreateTracker(from: tracker, withCategoryID: categoryID)
+	}
+
+	func editTracker(tracker: Tracker, categoryID: UUID) {
+		updateCreateTracker(from: tracker, withCategoryID: categoryID)
+	}
+
+	func removeTrackerBy(trackerID: UUID) {
+		guard let trackerCD = findObjectByUUID(
+			id: trackerID,
+			key: "trackerID",
+			withRequest: TrackerCD.fetchRequest()
+		) else { return }
+		mainContext.delete(trackerCD)
+		mainContext.saveContext()
+	}
+
+	func addCompletedTracker(trackerID: UUID, date: Date) {
+		completeUncompletedTracker(
+			trackerID: trackerID,
+			date: date
+		)
+	}
+
+	func cancelCompletedTracker(trackerID: UUID, date: Date) {
+		completeUncompletedTracker(
+			trackerID: trackerID,
+			date: date
+		)
+	}
+}
+
+// MARK: - Расширения доменных моделей - конвертации из объектов CD
+
+extension TrackerCategory {
+	static func convertFromCD(object: NSManagedObject) -> TrackerCategory? {
+		guard
+			let trackerCategoryCD = object as? TrackerCategoryCD,
+			let id = trackerCategoryCD.categoryID,
+			let title = trackerCategoryCD.title
+		else { return nil }
+
+		let trackersCD = trackerCategoryCD.trackers?.array as? [TrackerCD] ?? []
+		let trackers = trackersCD.compactMap { Tracker.convertFromCD(object: $0)?.id }
+
+		return TrackerCategory(
+			id: id,
+			title: title,
+			trackers: trackers
+		)
+	}
+}
+
+extension Tracker {
+	static func convertFromCD(object: NSManagedObject) -> Tracker? {
+		guard
+			let trackerCD = object as? TrackerCD,
+			let id = trackerCD.trackerID,
+			let title = trackerCD.title,
+			let emoji = trackerCD.emoji,
+			let color = trackerCD.color,
+			let scheduleString = trackerCD.schedule
+		else { return nil }
+
+		var schedule: [Int: Bool] = [:]
+		if !scheduleString.isEmpty {
+			// "0,2,3,4,0,6,7" - превратить в словарь
+			schedule = scheduleString.components(separatedBy: ",")
+				.enumerated()
+				.reduce(into: [:]) { result, keyValue in
+					if let number = Int(keyValue.element) {
+						result[keyValue.offset + 1] = number != 0
+					}
+				}
+		}
+
+		return Tracker(
+			id: id,
+			title: title,
+			emoji: emoji,
+			color: color,
+			schedule: schedule
+		)
+	}
+}
+
+extension TrackerRecord {
+	static func convertFromCD(object: NSManagedObject) -> TrackerRecord? {
+		guard
+			let trackerRecordCD = object as? TrackerRecordCD,
+			let id = trackerRecordCD.trackerID,
+			let dateString = trackerRecordCD.dateString
+		else { return nil }
+
+		// с проверкой даты не знаю что пока делать
+		let date = Theme.dateFormatterCD.date(from: dateString) ?? Date()
+		return TrackerRecord(trackerId: id, date: date)
+	}
+}

--- a/YP-Tracker/App/Services/CategoriesProvider.swift
+++ b/YP-Tracker/App/Services/CategoriesProvider.swift
@@ -53,14 +53,17 @@ final class CategoriesProvider: ICategoriesProvider {
 			tracker.id
 		}
 
+		// пока небольшая оптимизация - для CD этот модуль надо тоже переписать, особенно этот метод
+		let allCompletedTrackers = categoriesManager.getCompletedTrackers()
+
 		// получим список завершенных трекеров на переданную дату
-		completedTrackers = categoriesManager.getCompletedTrackers().filter { record in
+		completedTrackers = allCompletedTrackers.filter { record in
 			let isTheSameDay = calendar.isDate(record.date, inSameDayAs: date)
 			return trackersUUID.contains(record.trackerId) && isTheSameDay
 		}
 
 		// получим список сколько раз каждый трекер был выполнен
-		allTimesCompleted = categoriesManager.getCompletedTrackers()
+		allTimesCompleted = allCompletedTrackers
 			.reduce(into: [:]) { $0[$1.trackerId, default: 0] += 1 }
 
 		// дополнительно отфильтруем по фильтру трекеров

--- a/YP-Tracker/App/Services/CoreDataStack.swift
+++ b/YP-Tracker/App/Services/CoreDataStack.swift
@@ -1,0 +1,39 @@
+import Foundation
+import CoreData
+
+protocol ITrackersDataStore {
+	var persistentContainer: NSPersistentContainer { get }
+}
+
+final class CoreDataStack: ITrackersDataStore {
+
+	private let modelName: String
+
+	lazy var persistentContainer: NSPersistentContainer = {
+
+		let container = NSPersistentContainer(name: self.modelName)
+		container.loadPersistentStores { storeDescription, error in
+			print("DB = \(storeDescription)")
+			if let error = error as NSError? {
+				print("Error: \(error), \(error.userInfo)")
+			}
+		}
+		return container
+	}()
+
+	init(modelName: String) {
+		self.modelName = modelName
+	}
+}
+
+extension NSManagedObjectContext {
+	func saveContext() {
+		guard self.hasChanges else { return }
+
+		do {
+			try save()
+		} catch let error as NSError {
+			print("Core Data Error: \(error), \(error.userInfo)")
+		}
+	}
+}

--- a/YP-Tracker/Library/Trainer/CoreDataTrainerViewController.swift
+++ b/YP-Tracker/Library/Trainer/CoreDataTrainerViewController.swift
@@ -1,0 +1,426 @@
+import UIKit
+import CoreData
+
+// MARK: - Тренировочный экран
+
+final class CoreDataTrainerViewController: UIViewController {
+	private let calendar = Calendar.current
+	private var didSendEventClosure: ((CoreDataTrainerViewController.ButtonEvent) -> Void)?
+
+	private var fetchedResultsController = NSFetchedResultsController<TrackerCD>()
+
+	// ====
+	// Получим CoreData контейнер с базой данных.
+	private lazy var persistentContainer: NSPersistentContainer = makeContainer()
+
+	private var mainContext: NSManagedObjectContext {
+		persistentContainer.viewContext
+	}
+
+	private var backgroundContext: NSManagedObjectContext {
+		let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+		context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+		context.parent = self.mainContext
+		return context
+	}
+	// ====
+
+	// MARK: - UI
+	private lazy var createButton: UIButton = makeButtonByEvent(.create)
+	private lazy var deleteButton: UIButton = makeButtonByEvent(.delete)
+	private lazy var addCompletedButton: UIButton = makeButtonByEvent(.addCompleted)
+	private lazy var showCategoriesButton: UIButton = makeButtonByEvent(.showCategories)
+	private lazy var showCategoriesUpdateButton: UIButton = makeButtonByEvent(.showCategoriesUpdate)
+
+	// MARK: - Inits
+
+	deinit {
+		print("CoreDataTrainerViewController deinit")
+	}
+
+	// MARK: - Lifecycle
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		setup()
+		applyStyle()
+		setConstraints()
+	}
+}
+
+private extension CoreDataTrainerViewController {
+	func getSortDescriptor() -> [NSSortDescriptor] {
+		return [
+			NSSortDescriptor(
+				keyPath: \TrackerCD.trackerCategory?.title,
+				ascending: true
+			),
+			NSSortDescriptor(
+				key: "title",
+				ascending: true,
+				selector: #selector(NSString.localizedStandardCompare(_:)) // без этого неправильно сортировалось
+			)
+		]
+	}
+
+	func getPredicates(
+		date: Date,
+		text: String?,
+		completed: Bool?
+	) -> [NSPredicate] {
+		// обязательный предикат
+		let schedulePredicate = NSPredicate(
+			format: "schedule contains %@ || schedule == %@",
+			"\(calendar.component(.weekday, from: date))", // день недели
+			""
+		)
+
+		var predicates = [schedulePredicate]
+
+		// есть ли поиск по заголовку?
+		if let text = text {
+			let titleSeachPredicate = NSPredicate(
+				format: "title contains[c] %@",
+				text.lowercased()
+			)
+			predicates += [titleSeachPredicate]
+		}
+
+		// есть ли фильтр завершения
+		switch completed {
+		case .none:
+			break // здесь не фильтруем
+		case let .some(completed):
+			let completedUncompletedPredicate: NSPredicate
+			let dateString = Theme.dateFormatterCD.string(from: date)
+			if completed {
+				// оставляем только завершенные
+				completedUncompletedPredicate = NSPredicate(
+					format: "any trackerRecords.dateString == %@",
+					dateString
+				)
+			} else {
+				// оставляем только незавершенные
+				completedUncompletedPredicate = NSPredicate(
+					format: "any trackerRecords.dateString != %@ || trackerRecords.@count == 0",
+					dateString
+				)
+			}
+			predicates += [completedUncompletedPredicate]
+		}
+		return predicates
+	}
+
+	func makeFRC(
+		request: NSFetchRequest<TrackerCD>,
+		context: NSManagedObjectContext
+	) -> NSFetchedResultsController<TrackerCD> {
+		let rfc = NSFetchedResultsController(
+			fetchRequest: request,
+			managedObjectContext: context,
+			sectionNameKeyPath: #keyPath(TrackerCD.trackerCategory.title),
+			cacheName: nil
+		)
+		rfc.delegate = self
+		try? rfc.performFetch()
+
+		return rfc
+	}
+
+	func getCategories(
+		date: Date,
+		text: String?,
+		completed: Bool?
+	) {
+		// - подготовить новый запрос
+		let request = TrackerCD.fetchRequest()
+		// сортировка
+		request.sortDescriptors = getSortDescriptor()
+		// выборка
+		let predicates = getPredicates(
+			date: date,
+			text: text,
+			completed: completed
+		)
+		request.predicate = NSCompoundPredicate(
+			andPredicateWithSubpredicates: predicates
+		)
+		// - создать и выполнить новый frc
+		fetchedResultsController = makeFRC(
+			request: request,
+			context: mainContext
+		)
+	}
+}
+
+// MARK: - Core Data
+
+private extension CoreDataTrainerViewController {
+	func makeContainer() -> NSPersistentContainer {
+		// указываем модель по имени
+		let container = NSPersistentContainer(name: "TrackersMOC")
+		// добавляем хранилище, в дескрипторе тип и путь к базе
+		container.loadPersistentStores { storeDescription, error in
+			print("DB = \(storeDescription)")
+			if let error = error as NSError? {
+				fatalError("Unresolved error \(error), \(error.userInfo)")
+			}
+		}
+		return container
+	}
+
+	func createDB() {
+		let context = mainContext // persistentContainer.viewContext
+		let checkRequest = TrackerCategoryCD.fetchRequest()
+		do {
+			let result = try context.fetch(checkRequest)
+			// Если есть данные в базе, то выходим
+			if !result.isEmpty { return }
+		} catch let error as NSError {
+			print("Core Data Error:  \(error), \(error.userInfo)")
+			return
+		}
+
+		// Данных нет, загружаем
+		let repository = TrackerCategoriesStub()
+
+		let categories: [TrackerCategoryCD] = repository.getCategories().map { category in
+			let categoryCD = TrackerCategoryCD(context: context)
+			categoryCD.categoryID = category.id
+			categoryCD.title = category.title
+			return categoryCD
+		}
+
+		let trackers: [TrackerCD] = repository.getTrackers().map { tracker in
+			let trackerCD = TrackerCD(context: context)
+			trackerCD.trackerID = tracker.id
+			trackerCD.title = tracker.title
+			trackerCD.emoji = tracker.emoji
+			trackerCD.color = tracker.color
+			trackerCD.schedule = tracker.scheduleCD
+			return trackerCD
+		}
+
+		categories[0].addToTrackers(trackers[0])
+		categories[1].addToTrackers(trackers[1])
+		categories[2].addToTrackers([trackers[2], trackers[3], trackers[4]])
+
+		let trackerRecordCD = TrackerRecordCD(context: context)
+		trackerRecordCD.trackerID = trackers[0].trackerID
+		trackerRecordCD.dateString = Theme.dateFormatterCD.string(from: Date())
+
+		trackers[0].addToTrackerRecords(trackerRecordCD)
+
+		do {
+			try context.save()
+			print("Загрузили категории и трекеры")
+		} catch let error as NSError {
+			print("Core Data Error:  \(error), \(error.userInfo)")
+		}
+	}
+
+	func deleteDB() {
+		let backgroundContext = self.backgroundContext
+
+		backgroundContext.performAndWait {
+			let fetchRequest: NSFetchRequest<NSFetchRequestResult> = TrackerCategoryCD.fetchRequest()
+			let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+			do {
+				try backgroundContext.execute(batchDeleteRequest)
+				try backgroundContext.save()
+				print("Удалили трекеры")
+			} catch let error as NSError {
+				print("Core Data Error:  \(error), \(error.userInfo)")
+			}
+		}
+	}
+
+	func addCompleted() {
+		let isOK = completeUncompleteTrackerByPlace(section: 0, row: 0, date: Date())
+	}
+
+	func completeUncompleteTrackerByPlace(section: Int, row: Int, date: Date) -> Bool {
+		// проверка на наличие данных
+		guard fetchedResultsController.sections != nil else { return false }
+
+		let indexPath: IndexPath = .init(row: row, section: section)
+		let object = fetchedResultsController.object(at: indexPath)
+		// удалять или добавлять?
+
+		let dateString = Theme.dateFormatterCD.string(from: date)
+		// попытаемся найти с этой датой
+		if let records = object.trackerRecords as? Set<TrackerRecordCD>,
+		   let record = records.first(where: { $0.dateString == dateString }) {
+			// удалить
+			object.removeFromTrackerRecords(record)
+		} else {
+			// добавить
+			let newRecord = TrackerRecordCD(context: mainContext)
+			newRecord.dateString = dateString
+			newRecord.trackerID = object.trackerID
+
+			object.addToTrackerRecords(newRecord)
+		}
+		return true
+	}
+
+	func show(date: Date) {
+		// проверка на наличие данных
+		guard let sections = fetchedResultsController.sections else { return }
+
+		let dateString = Theme.dateFormatterCD.string(from: date)
+		print("--------- Показываем на дату: \(dateString)")
+
+		for section in sections {
+			print("Категория: ", section.name)
+			guard let trackers = section.objects as? [TrackerCD] else { continue }
+			for tracker in trackers {
+				print(tracker.title ?? "", tracker.trackerRecords?.count ?? 0)
+				// определить завершенный ли трекер на выбранный день
+				if let records = tracker.trackerRecords as? Set<TrackerRecordCD> {
+					let dates = records.map { $0.dateString }
+					print(dates.contains(dateString))
+				}
+			}
+			print("---------------")
+		}
+		print("xxxxxxxxxxxxxxxx")
+
+		showTrackers()
+	}
+
+	func showTrackers() {
+		guard let trackers = fetchedResultsController.fetchedObjects else { return }
+		for tracker in trackers {
+			print("Tr:")
+			print(
+				tracker.title ?? "",
+				tracker.color ?? "",
+				tracker.emoji ?? "",
+				tracker.trackerID ?? ""
+			)
+		}
+	}
+
+	func showCategories() {
+		let date = Date()
+		getCategories(date: date, text: nil, completed: nil)
+		show(date: date)
+	}
+
+	func showCategoriesUpdate() {
+		let date = Date()
+		getCategories(date: date, text: nil, completed: true)
+		show(date: date)
+	}
+}
+
+// MARK: - UI
+private extension CoreDataTrainerViewController {
+	func setup() {
+		didSendEventClosure = { [weak self] event in
+			switch event {
+			case .create:
+				print("Создать БД")
+				self?.createDB()
+			case .delete:
+				print("Удалить БД")
+				self?.deleteDB()
+			case .addCompleted:
+				print("Завершить первый трекер")
+				self?.addCompleted()
+			case .showCategories:
+				print("Показать категории")
+				self?.showCategories()
+			case .showCategoriesUpdate:
+				print("Показать новые категории")
+				self?.showCategoriesUpdate()
+			}
+		}
+	}
+	func applyStyle() {
+		view.backgroundColor = Theme.color(usage: .white)
+	}
+	func setConstraints() {
+		let stackView = UIStackView()
+		stackView.axis = .vertical
+		stackView.spacing = Theme.spacing(usage: .standard)
+
+		[
+			createButton,
+			deleteButton,
+			addCompletedButton,
+			showCategoriesButton,
+			showCategoriesUpdateButton
+		].forEach { item in
+			stackView.addArrangedSubview(item)
+			item.makeConstraints { make in
+				make.size(.init(width: Appearance.buttonSize.width, height: Appearance.buttonSize.height))
+			}
+		}
+
+		view.addSubview(stackView)
+		stackView.makeEqualToSuperviewCenter()
+	}
+}
+
+// MARK: - UI make
+private extension CoreDataTrainerViewController {
+	func makeButtonByEvent(_ event: ButtonEvent) -> UIButton {
+		let button = UIButton()
+		button.titleLabel?.font = Theme.font(style: .callout)
+		button.backgroundColor = Theme.color(usage: .accent)
+		button.setTitleColor(Theme.color(usage: .attention), for: .normal)
+		button.layer.cornerRadius = Theme.size(kind: .cornerRadius)
+
+		switch event {
+		case .create:
+			button.setTitle("Создать БД", for: .normal)
+			button.event = { [weak self] in
+				self?.didSendEventClosure?(.create)
+			}
+		case .delete:
+			button.setTitle("Удалить БД", for: .normal)
+			button.event = { [weak self] in
+				self?.didSendEventClosure?(.delete)
+			}
+		case .addCompleted:
+			button.setTitle("Завершить трекер", for: .normal)
+			button.event = { [weak self] in
+				self?.didSendEventClosure?(.addCompleted)
+			}
+		case .showCategories:
+			button.setTitle("Показать категории", for: .normal)
+			button.event = { [weak self] in
+				self?.didSendEventClosure?(.showCategories)
+			}
+		case .showCategoriesUpdate:
+			button.setTitle("Показать новые категории", for: .normal)
+			button.event = { [weak self] in
+				self?.didSendEventClosure?(.showCategoriesUpdate)
+			}
+		}
+
+		return button
+	}
+}
+
+extension CoreDataTrainerViewController: NSFetchedResultsControllerDelegate {}
+
+// MARK: - ButtonEvent
+private extension CoreDataTrainerViewController {
+	enum ButtonEvent {
+		case create
+		case delete
+		case addCompleted
+		case showCategories
+		case showCategoriesUpdate
+	}
+}
+
+// MARK: - Appearance
+private extension CoreDataTrainerViewController {
+	enum Appearance {
+		static let buttonSize: CGSize = .init(width: 200, height: 50)
+	}
+}

--- a/YP-Tracker/Models/CoreData/TrackerCD+CoreDataProperties.swift
+++ b/YP-Tracker/Models/CoreData/TrackerCD+CoreDataProperties.swift
@@ -1,0 +1,37 @@
+import Foundation
+import CoreData
+
+// swiftlint:disable missing_docs
+extension TrackerCD {
+
+	@nonobjc public class func fetchRequest() -> NSFetchRequest<TrackerCD> {
+		return NSFetchRequest<TrackerCD>(entityName: "TrackerCD")
+	}
+
+	@NSManaged public var color: String?
+	@NSManaged public var emoji: String?
+	@NSManaged public var schedule: String?
+	@NSManaged public var title: String?
+	@NSManaged public var trackerID: UUID?
+	@NSManaged public var trackerCategory: TrackerCategoryCD?
+	@NSManaged public var trackerRecords: NSSet?
+}
+
+// MARK: Generated accessors for trackerRecords
+extension TrackerCD {
+
+	@objc(addTrackerRecordsObject:)
+	@NSManaged public func addToTrackerRecords(_ value: TrackerRecordCD)
+
+	@objc(removeTrackerRecordsObject:)
+	@NSManaged public func removeFromTrackerRecords(_ value: TrackerRecordCD)
+
+	@objc(addTrackerRecords:)
+	@NSManaged public func addToTrackerRecords(_ values: NSSet)
+
+	@objc(removeTrackerRecords:)
+	@NSManaged public func removeFromTrackerRecords(_ values: NSSet)
+}
+
+extension TrackerCD: Identifiable {}
+// swiftlint:enable missing_docs

--- a/YP-Tracker/Models/CoreData/TrackerCD.swift
+++ b/YP-Tracker/Models/CoreData/TrackerCD.swift
@@ -1,0 +1,5 @@
+import Foundation
+import CoreData
+
+@objc(TrackerCD)
+public class TrackerCD: NSManagedObject {}

--- a/YP-Tracker/Models/CoreData/TrackerCategoryCD+CoreDataProperties.swift
+++ b/YP-Tracker/Models/CoreData/TrackerCategoryCD+CoreDataProperties.swift
@@ -1,0 +1,51 @@
+import Foundation
+import CoreData
+
+// swiftlint:disable missing_docs
+extension TrackerCategoryCD {
+
+	@nonobjc public class func fetchRequest() -> NSFetchRequest<TrackerCategoryCD> {
+		return NSFetchRequest<TrackerCategoryCD>(entityName: "TrackerCategoryCD")
+	}
+
+	@NSManaged public var categoryID: UUID?
+	@NSManaged public var title: String?
+	@NSManaged public var trackers: NSOrderedSet?
+}
+
+// MARK: Generated accessors for trackers
+extension TrackerCategoryCD {
+
+	@objc(insertObject:inTrackersAtIndex:)
+	@NSManaged public func insertIntoTrackers(_ value: TrackerCD, at idx: Int)
+
+	@objc(removeObjectFromTrackersAtIndex:)
+	@NSManaged public func removeFromTrackers(at idx: Int)
+
+	@objc(insertTrackers:atIndexes:)
+	@NSManaged public func insertIntoTrackers(_ values: [TrackerCD], at indexes: NSIndexSet)
+
+	@objc(removeTrackersAtIndexes:)
+	@NSManaged public func removeFromTrackers(at indexes: NSIndexSet)
+
+	@objc(replaceObjectInTrackersAtIndex:withObject:)
+	@NSManaged public func replaceTrackers(at idx: Int, with value: TrackerCD)
+
+	@objc(replaceTrackersAtIndexes:withTrackers:)
+	@NSManaged public func replaceTrackers(at indexes: NSIndexSet, with values: [TrackerCD])
+
+	@objc(addTrackersObject:)
+	@NSManaged public func addToTrackers(_ value: TrackerCD)
+
+	@objc(removeTrackersObject:)
+	@NSManaged public func removeFromTrackers(_ value: TrackerCD)
+
+	@objc(addTrackers:)
+	@NSManaged public func addToTrackers(_ values: NSOrderedSet)
+
+	@objc(removeTrackers:)
+	@NSManaged public func removeFromTrackers(_ values: NSOrderedSet)
+}
+
+extension TrackerCategoryCD: Identifiable {}
+// swiftlint:enable missing_docs

--- a/YP-Tracker/Models/CoreData/TrackerCategoryCD.swift
+++ b/YP-Tracker/Models/CoreData/TrackerCategoryCD.swift
@@ -1,0 +1,5 @@
+import Foundation
+import CoreData
+
+@objc(TrackerCategoryCD)
+public class TrackerCategoryCD: NSManagedObject {}

--- a/YP-Tracker/Models/CoreData/TrackerRecordCD+CoreDataProperties.swift
+++ b/YP-Tracker/Models/CoreData/TrackerRecordCD+CoreDataProperties.swift
@@ -1,0 +1,17 @@
+import Foundation
+import CoreData
+
+// swiftlint:disable missing_docs
+extension TrackerRecordCD {
+
+	@nonobjc public class func fetchRequest() -> NSFetchRequest<TrackerRecordCD> {
+		return NSFetchRequest<TrackerRecordCD>(entityName: "TrackerRecordCD")
+	}
+
+	@NSManaged public var dateString: String?
+	@NSManaged public var trackerID: UUID?
+	@NSManaged public var tracker: TrackerCD?
+}
+
+extension TrackerRecordCD: Identifiable {}
+// swiftlint:enable missing_docs

--- a/YP-Tracker/Models/CoreData/TrackerRecordCD.swift
+++ b/YP-Tracker/Models/CoreData/TrackerRecordCD.swift
@@ -1,0 +1,5 @@
+import Foundation
+import CoreData
+
+@objc(TrackerRecordCD)
+public class TrackerRecordCD: NSManagedObject {}

--- a/YP-Tracker/Models/Tracker.swift
+++ b/YP-Tracker/Models/Tracker.swift
@@ -20,6 +20,19 @@ struct Tracker: Identifiable, Hashable {
 		}
 	}
 
+	var scheduleCD: String {
+		return schedule
+			.sorted { $0.key < $1.key }
+			.map { key, value -> String in
+				if value {
+					return "\(key)" // "1" // пока думаю использовать ключ или 1
+				} else {
+					return "0"
+				}
+			}
+			.joined(separator: ",")
+	}
+
 	static func makeWeekDays() -> [String] {
 		let calendar = Calendar.current
 		let numDays: Int = calendar.weekdaySymbols.count

--- a/YP-Tracker/Models/TrackersMOC.xcdatamodeld/TrackersMOC.xcdatamodel/contents
+++ b/YP-Tracker/Models/TrackersMOC.xcdatamodeld/TrackersMOC.xcdatamodel/contents
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G1231" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="TrackerCategoryCD" representedClassName="TrackerCategoryCD" syncable="YES">
+        <attribute name="categoryID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="trackers" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="TrackerCD" inverseName="trackerCategory" inverseEntity="TrackerCD"/>
+    </entity>
+    <entity name="TrackerCD" representedClassName="TrackerCD" syncable="YES">
+        <attribute name="color" attributeType="String"/>
+        <attribute name="emoji" attributeType="String"/>
+        <attribute name="schedule" attributeType="String" minValueString="0" maxValueString="13" defaultValueString="&quot;&quot;"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="trackerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="trackerCategory" maxCount="1" deletionRule="Nullify" destinationEntity="TrackerCategoryCD" inverseName="trackers" inverseEntity="TrackerCategoryCD"/>
+        <relationship name="trackerRecords" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TrackerRecordCD" inverseName="tracker" inverseEntity="TrackerRecordCD"/>
+    </entity>
+    <entity name="TrackerRecordCD" representedClassName="TrackerRecordCD" syncable="YES">
+        <attribute name="dateString" attributeType="String" minValueString="10" maxValueString="10"/>
+        <attribute name="trackerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="tracker" maxCount="1" deletionRule="Nullify" destinationEntity="TrackerCD" inverseName="trackerRecords" inverseEntity="TrackerCD"/>
+    </entity>
+    <elements>
+        <element name="TrackerCategoryCD" positionX="-786.9605712890625" positionY="-186.1984252929688" width="128" height="88"/>
+        <element name="TrackerCD" positionX="-620.7967529296875" positionY="-105.1240234375" width="128" height="148"/>
+        <element name="TrackerRecordCD" positionX="-455.98046875" positionY="2.3961181640625" width="128" height="88"/>
+    </elements>
+</model>

--- a/YP-Tracker/Models/TrackersOM.xcdatamodeld/Trackers.xcdatamodel/contents
+++ b/YP-Tracker/Models/TrackersOM.xcdatamodeld/Trackers.xcdatamodel/contents
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G1231" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="TrackerCD" representedClassName="TrackerCD" syncable="YES" codeGenerationType="class">
+        <attribute name="color" attributeType="String"/>
+        <attribute name="emoji" attributeType="String"/>
+        <attribute name="schedule" attributeType="String" minValueString="0" maxValueString="13" defaultValueString="&quot;&quot;"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="trackerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="trackerRecords" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TrackerRecordCD" inverseName="tracker" inverseEntity="TrackerRecordCD"/>
+    </entity>
+    <entity name="TrackerRecordCD" representedClassName="TrackerRecordCD" syncable="YES" codeGenerationType="class">
+        <attribute name="date" attributeType="String" minValueString="10" maxValueString="10"/>
+        <attribute name="trackerID" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="tracker" maxCount="1" deletionRule="Nullify" destinationEntity="TrackerCD" inverseName="trackerRecords" inverseEntity="TrackerCD"/>
+    </entity>
+    <elements>
+        <element name="TrackerCD" positionX="-73.747802734375" positionY="17.8311767578125" width="128" height="133"/>
+        <element name="TrackerRecordCD" positionX="184.4802856445312" positionY="37.55166625976562" width="128" height="88"/>
+    </elements>
+</model>

--- a/YP-Tracker/Modules/Trackers/TrackersInteractor.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersInteractor.swift
@@ -46,7 +46,6 @@ final class TrackersInteractor: ITrackersInteractor {
 			conditions.searchText = text
 		case let .newDate(date):
 			conditions.date = date
-			// странный фильтр .today, если можем менять дату, то значит меняем и фильтр
 			if conditions.filter == .today {
 				conditions.filter = .all
 			}
@@ -58,6 +57,9 @@ final class TrackersInteractor: ITrackersInteractor {
 			) else { return }
 		case let .newFilter(filter):
 			conditions.filter = filter
+			if filter == .today {
+				conditions.date = Date()
+			}
 		case .addTracker:
 			didSendEventClosure?(.addTracker)
 			return
@@ -76,13 +78,7 @@ private extension TrackersInteractor {
 		conditions.hasAnyTrackers = categoriesProvider.hasAnyTrakers
 
 		switch conditions.filter {
-		case .today:
-			categories = categoriesProvider.getCategories(
-				date: Date(),
-				text: conditions.searchText,
-				completed: nil
-			)
-		case .all:
+		case .today, .all:
 			categories = categoriesProvider.getCategories(
 				date: conditions.date,
 				text: conditions.searchText,

--- a/YP-Tracker/Resources/Theme/Theme+DateFormatter.swift
+++ b/YP-Tracker/Resources/Theme/Theme+DateFormatter.swift
@@ -8,4 +8,11 @@ extension Theme {
 		formatter.timeStyle = .none
 		return formatter
 	}()
+
+	static let dateFormatterCD: DateFormatter = {
+		let formatter = DateFormatter()
+		formatter.dateFormat = "dd.MM.yyyy"
+		formatter.locale = Locale(identifier: "ru-RU")
+		return formatter
+	}()
 }


### PR DESCRIPTION
## Описание к работе
1. добавление новой привычки - было сделано еще на 14 спринте
2. добавлен слой работы с БД - из слоя данных подменил пока только manager #2 , provider тоже стоит подменить, так как Core Data позволяет сразу сделать правильную выборку
### по чек листу п.3
- добавленные классы называются несколько по другому
- у каждой сущности есть постфикс CD
- взаимосвязи есть, не разобрался в чем профит галочки Ordered, в одном месте поставил, в другом нет)
<img width="260" alt="image" src="https://github.com/SShliakhin/YP-Tracker/assets/71236551/57f73bf4-2672-4363-9656-cff651446139">

- контейнер есть, но пока не знаю как его лучше инъектить в свой Di
- не смог найти места для FRC в архитектуре Clean Swift, конечно были идеи немного нарушить концепцию, но последней каплей стало знание, что нам придется делать дальше - реализовывать пины для трекеров, здесь FRC вообще не знаю как может помочь?

### дополнительно: 
- CoreDataTrainerViewController.swift - экран/модуль для тренировок, еще пригодится, можно не смотреть
- буду рад, если вы подскажите, что и как можно улучшить в моем решении
