### PR TITLE
Sprint 16: MVVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 * Clean Swift
 * Navigation: Coordinator
 * DI: на базе фабрик
+* Persistence storage: Core Data
 * Layout: Anchors, CompositionalLayout
 * Fonts: YSDisplay
 

--- a/YP-Tracker.xcodeproj/project.pbxproj
+++ b/YP-Tracker.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		5A8D1DB72A0DAFAB00A2924F /* TrackerRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8D1DB22A0DAFAB00A2924F /* TrackerRecord.swift */; };
 		5A91DED829E0DF58001A23C3 /* UIView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A91DED729E0DF58001A23C3 /* UIView+Constraints.swift */; };
 		5A91DEDA29E12F82001A23C3 /* UIViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A91DED929E12F82001A23C3 /* UIViewController+Preview.swift */; };
+		5A9CFECB2A4F797E0044A189 /* CategoriesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9CFECA2A4F797E0044A189 /* CategoriesListViewModel.swift */; };
+		5A9CFECD2A4F7BA70044A189 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9CFECC2A4F7BA70044A189 /* Observable.swift */; };
+		5A9CFECF2A4F7E780044A189 /* CategoriesListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9CFECE2A4F7E780044A189 /* CategoriesListItemViewModel.swift */; };
 		5AA5FA2B2A13CDCC0056633B /* ICellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5FA2A2A13CDCC0056633B /* ICellViewModel.swift */; };
 		5AA5FA2E2A13CE4F0056633B /* UICollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5FA2C2A13CE4F0056633B /* UICollectionView+Extensions.swift */; };
 		5AA5FA2F2A13CE4F0056633B /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5FA2D2A13CE4F0056633B /* UITableView+Extensions.swift */; };
@@ -61,6 +64,7 @@
 		5AA7AD102A16AA590022C334 /* HeaderSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA7AD0F2A16AA590022C334 /* HeaderSupplementaryView.swift */; };
 		5ACDBE1F2A4B8C6E00F86895 /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDBE1E2A4B8C6E00F86895 /* PageViewController.swift */; };
 		5ACDBE212A4C733100F86895 /* OnboardingInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDBE202A4C733100F86895 /* OnboardingInteractor.swift */; };
+		5ACDBE242A4E848600F86895 /* SelectCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDBE232A4E848600F86895 /* SelectCategoryViewController.swift */; };
 		5ADD1F0429E358F50072EE78 /* YSDisplay-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ADD1F0129E358F40072EE78 /* YSDisplay-Regular.ttf */; };
 		5ADD1F0529E358F50072EE78 /* YSDisplay-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ADD1F0229E358F50072EE78 /* YSDisplay-Bold.ttf */; };
 		5ADD1F0629E358F50072EE78 /* YSDisplay-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ADD1F0329E358F50072EE78 /* YSDisplay-Medium.ttf */; };
@@ -170,6 +174,9 @@
 		5A8D1DB22A0DAFAB00A2924F /* TrackerRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerRecord.swift; sourceTree = "<group>"; };
 		5A91DED729E0DF58001A23C3 /* UIView+Constraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Constraints.swift"; sourceTree = "<group>"; };
 		5A91DED929E12F82001A23C3 /* UIViewController+Preview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Preview.swift"; sourceTree = "<group>"; };
+		5A9CFECA2A4F797E0044A189 /* CategoriesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesListViewModel.swift; sourceTree = "<group>"; };
+		5A9CFECC2A4F7BA70044A189 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		5A9CFECE2A4F7E780044A189 /* CategoriesListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesListItemViewModel.swift; sourceTree = "<group>"; };
 		5AA5FA2A2A13CDCC0056633B /* ICellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ICellViewModel.swift; sourceTree = "<group>"; };
 		5AA5FA2C2A13CE4F0056633B /* UICollectionView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extensions.swift"; sourceTree = "<group>"; };
 		5AA5FA2D2A13CE4F0056633B /* UITableView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
@@ -183,6 +190,7 @@
 		5AA7AD0F2A16AA590022C334 /* HeaderSupplementaryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderSupplementaryView.swift; sourceTree = "<group>"; };
 		5ACDBE1E2A4B8C6E00F86895 /* PageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
 		5ACDBE202A4C733100F86895 /* OnboardingInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInteractor.swift; sourceTree = "<group>"; };
+		5ACDBE232A4E848600F86895 /* SelectCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCategoryViewController.swift; sourceTree = "<group>"; };
 		5ADD1F0129E358F40072EE78 /* YSDisplay-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "YSDisplay-Regular.ttf"; sourceTree = "<group>"; };
 		5ADD1F0229E358F50072EE78 /* YSDisplay-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "YSDisplay-Bold.ttf"; sourceTree = "<group>"; };
 		5ADD1F0329E358F50072EE78 /* YSDisplay-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "YSDisplay-Medium.ttf"; sourceTree = "<group>"; };
@@ -412,6 +420,7 @@
 				5A45EA5E2A0CE7AB003269D3 /* Statistics */,
 				5AE6BDEA2A1919BF0068CB53 /* YPModule */,
 				5A8D1DAE2A0D6EE100A2924F /* SelectTypeTracker */,
+				5A9CFED02A50FC630044A189 /* SelectCategoryMVVM */,
 				5A84742E2A0F56AE00C2F93E /* CreateEditTracker */,
 				5A2837652A3E53C600513B91 /* CreateEditCategory */,
 			);
@@ -470,8 +479,27 @@
 				5A61DD3C29E13FF9001E8665 /* UIView+Preview.swift */,
 				5A91DED729E0DF58001A23C3 /* UIView+Constraints.swift */,
 				5AE6BDE62A18187A0068CB53 /* CellCorner.swift */,
+				5A9CFECC2A4F7BA70044A189 /* Observable.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		5A9CFED02A50FC630044A189 /* SelectCategoryMVVM */ = {
+			isa = PBXGroup;
+			children = (
+				5A9CFED12A50FC980044A189 /* ViewModel */,
+				5ACDBE232A4E848600F86895 /* SelectCategoryViewController.swift */,
+			);
+			path = SelectCategoryMVVM;
+			sourceTree = "<group>";
+		};
+		5A9CFED12A50FC980044A189 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				5A9CFECA2A4F797E0044A189 /* CategoriesListViewModel.swift */,
+				5A9CFECE2A4F7E780044A189 /* CategoriesListItemViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		5AA5FA292A13CDCC0056633B /* Protocols */ = {
@@ -807,12 +835,14 @@
 				5AE1F0152A0948A000103F08 /* Di+CoordinatorFactory.swift in Sources */,
 				5A4668A12A1AA5D300FEBD9B /* CreateEditTrackerInteractor.swift in Sources */,
 				5A48063A29DBC5690096B7D8 /* Theme+Fonts.swift in Sources */,
+				5A9CFECF2A4F7E780044A189 /* CategoriesListItemViewModel.swift in Sources */,
 				5AA7AD0C2A1647550022C334 /* TrackersInteractor.swift in Sources */,
 				5AE12A302A0BBD860054D782 /* TabbarCoordinator.swift in Sources */,
 				5AE1F0262A09628400103F08 /* OnboardingViewController.swift in Sources */,
 				5ADD1F0A29E38E6E0072EE78 /* UIColor+Dynamic.swift in Sources */,
 				5AE12A3B2A0BE8CF0054D782 /* TabbarViewController.swift in Sources */,
 				5A28375E2A3E436D00513B91 /* CreateEditCategoryModels.swift in Sources */,
+				5A9CFECB2A4F797E0044A189 /* CategoriesListViewModel.swift in Sources */,
 				5AF5CAF92A12D0A4004AB8D2 /* TrackerFilter.swift in Sources */,
 				5AFC98B52A366735005E3C4D /* TrackersMOC.xcdatamodeld in Sources */,
 				5AE1F0192A0948B100103F08 /* Di+ModuleFactory.swift in Sources */,
@@ -829,6 +859,7 @@
 				5A2837642A3E515A00513B91 /* CreateEditCategoryViewController.swift in Sources */,
 				5AF35C162A44B7EE00BC1C3A /* OnboardingPage.swift in Sources */,
 				5A1DFF032A3B847200AD63F3 /* TrackerCategoryCD.swift in Sources */,
+				5ACDBE242A4E848600F86895 /* SelectCategoryViewController.swift in Sources */,
 				5AA5FA322A1409420056633B /* TrackerColorCell.swift in Sources */,
 				5AE12A252A0B90390054D782 /* Theme+Colors.swift in Sources */,
 				5AF5CAF42A124EA4004AB8D2 /* CategoriesProvider.swift in Sources */,
@@ -853,6 +884,7 @@
 				5AE12A322A0BC70F0054D782 /* TrackersCoordinator.swift in Sources */,
 				5A1DFF022A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift in Sources */,
 				5A84742B2A0E91BC00C2F93E /* CreateEditTrackerCoordinator.swift in Sources */,
+				5A9CFECD2A4F7BA70044A189 /* Observable.swift in Sources */,
 				5AE1F00C2A0944D400103F08 /* IRouter.swift in Sources */,
 				5A46689F2A1AA55300FEBD9B /* CreateEditTrackerModels.swift in Sources */,
 				5A77EF642A2891DE000CF24C /* SelectTypeTrackerModels.swift in Sources */,

--- a/YP-Tracker.xcodeproj/project.pbxproj
+++ b/YP-Tracker.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		5AA7AD0C2A1647550022C334 /* TrackersInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA7AD0B2A1647550022C334 /* TrackersInteractor.swift */; };
 		5AA7AD0E2A1648E20022C334 /* TrackersPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA7AD0D2A1648E20022C334 /* TrackersPresenter.swift */; };
 		5AA7AD102A16AA590022C334 /* HeaderSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA7AD0F2A16AA590022C334 /* HeaderSupplementaryView.swift */; };
+		5ACDBE1F2A4B8C6E00F86895 /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDBE1E2A4B8C6E00F86895 /* PageViewController.swift */; };
+		5ACDBE212A4C733100F86895 /* OnboardingInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDBE202A4C733100F86895 /* OnboardingInteractor.swift */; };
 		5ADD1F0429E358F50072EE78 /* YSDisplay-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ADD1F0129E358F40072EE78 /* YSDisplay-Regular.ttf */; };
 		5ADD1F0529E358F50072EE78 /* YSDisplay-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ADD1F0229E358F50072EE78 /* YSDisplay-Bold.ttf */; };
 		5ADD1F0629E358F50072EE78 /* YSDisplay-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5ADD1F0329E358F50072EE78 /* YSDisplay-Medium.ttf */; };
@@ -179,6 +181,8 @@
 		5AA7AD0B2A1647550022C334 /* TrackersInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackersInteractor.swift; sourceTree = "<group>"; };
 		5AA7AD0D2A1648E20022C334 /* TrackersPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackersPresenter.swift; sourceTree = "<group>"; };
 		5AA7AD0F2A16AA590022C334 /* HeaderSupplementaryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderSupplementaryView.swift; sourceTree = "<group>"; };
+		5ACDBE1E2A4B8C6E00F86895 /* PageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
+		5ACDBE202A4C733100F86895 /* OnboardingInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInteractor.swift; sourceTree = "<group>"; };
 		5ADD1F0129E358F40072EE78 /* YSDisplay-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "YSDisplay-Regular.ttf"; sourceTree = "<group>"; };
 		5ADD1F0229E358F50072EE78 /* YSDisplay-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "YSDisplay-Bold.ttf"; sourceTree = "<group>"; };
 		5ADD1F0329E358F50072EE78 /* YSDisplay-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "YSDisplay-Medium.ttf"; sourceTree = "<group>"; };
@@ -496,6 +500,15 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		5ACDBE222A4C801200F86895 /* PageViewController */ = {
+			isa = PBXGroup;
+			children = (
+				5AF35C172A44BCCC00BC1C3A /* OnboardingPageViewController.swift */,
+				5ACDBE1E2A4B8C6E00F86895 /* PageViewController.swift */,
+			);
+			path = PageViewController;
+			sourceTree = "<group>";
+		};
 		5ADD1F0B29E38ECA0072EE78 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -570,8 +583,9 @@
 		5AE1F01D2A09628300103F08 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				5ACDBE222A4C801200F86895 /* PageViewController */,
+				5ACDBE202A4C733100F86895 /* OnboardingInteractor.swift */,
 				5AE1F01E2A09628300103F08 /* OnboardingViewController.swift */,
-				5AF35C172A44BCCC00BC1C3A /* OnboardingPageViewController.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -827,6 +841,7 @@
 				5AE6BDED2A1924580068CB53 /* YPViewController.swift in Sources */,
 				5AA5FA332A1409420056633B /* TrackerEmojiCell.swift in Sources */,
 				5AE6BDF12A197E610068CB53 /* YPInteractor.swift in Sources */,
+				5ACDBE212A4C733100F86895 /* OnboardingInteractor.swift in Sources */,
 				5A2837602A3E457C00513B91 /* CreateEditCategoryInteractor.swift in Sources */,
 				5AA5FA2B2A13CDCC0056633B /* ICellViewModel.swift in Sources */,
 				5AE12A272A0B926D0054D782 /* Theme+Images.swift in Sources */,
@@ -834,6 +849,7 @@
 				5A45EA682A0D22CE003269D3 /* EmptyView.swift in Sources */,
 				5A91DEDA29E12F82001A23C3 /* UIViewController+Preview.swift in Sources */,
 				5AA7AD102A16AA590022C334 /* HeaderSupplementaryView.swift in Sources */,
+				5ACDBE1F2A4B8C6E00F86895 /* PageViewController.swift in Sources */,
 				5AE12A322A0BC70F0054D782 /* TrackersCoordinator.swift in Sources */,
 				5A1DFF022A3B847200AD63F3 /* TrackerCD+CoreDataProperties.swift in Sources */,
 				5A84742B2A0E91BC00C2F93E /* CreateEditTrackerCoordinator.swift in Sources */,

--- a/YP-Tracker.xcodeproj/project.pbxproj
+++ b/YP-Tracker.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		5AE6BDF12A197E610068CB53 /* YPInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6BDF02A197E610068CB53 /* YPInteractor.swift */; };
 		5AE6BDF32A1989D30068CB53 /* YPPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6BDF22A1989D30068CB53 /* YPPresenter.swift */; };
 		5AE6BDF52A19D8770068CB53 /* TrackerConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6BDF42A19D8770068CB53 /* TrackerConditions.swift */; };
+		5AF35C162A44B7EE00BC1C3A /* OnboardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF35C152A44B7EE00BC1C3A /* OnboardingPage.swift */; };
+		5AF35C182A44BCCC00BC1C3A /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF35C172A44BCCC00BC1C3A /* OnboardingPageViewController.swift */; };
 		5AF5CAF22A12385F004AB8D2 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5CAF12A12385F004AB8D2 /* Repository.swift */; };
 		5AF5CAF42A124EA4004AB8D2 /* CategoriesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5CAF32A124EA4004AB8D2 /* CategoriesProvider.swift */; };
 		5AF5CAF62A125333004AB8D2 /* CategoriesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5CAF52A125333004AB8D2 /* CategoriesManager.swift */; };
@@ -209,6 +211,8 @@
 		5AE6BDF02A197E610068CB53 /* YPInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPInteractor.swift; sourceTree = "<group>"; };
 		5AE6BDF22A1989D30068CB53 /* YPPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPPresenter.swift; sourceTree = "<group>"; };
 		5AE6BDF42A19D8770068CB53 /* TrackerConditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerConditions.swift; sourceTree = "<group>"; };
+		5AF35C152A44B7EE00BC1C3A /* OnboardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPage.swift; sourceTree = "<group>"; };
+		5AF35C172A44BCCC00BC1C3A /* OnboardingPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageViewController.swift; sourceTree = "<group>"; };
 		5AF5CAF12A12385F004AB8D2 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		5AF5CAF32A124EA4004AB8D2 /* CategoriesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesProvider.swift; sourceTree = "<group>"; };
 		5AF5CAF52A125333004AB8D2 /* CategoriesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesManager.swift; sourceTree = "<group>"; };
@@ -388,6 +392,7 @@
 				5A8D1DB12A0DAFAB00A2924F /* TrackerColor.swift */,
 				5AF5CAF82A12D0A4004AB8D2 /* TrackerFilter.swift */,
 				5AE6BDF42A19D8770068CB53 /* TrackerConditions.swift */,
+				5AF35C152A44B7EE00BC1C3A /* OnboardingPage.swift */,
 				5A1DFF072A3B860A00AD63F3 /* CoreData */,
 				5AFC98B32A366735005E3C4D /* TrackersMOC.xcdatamodeld */,
 			);
@@ -566,6 +571,7 @@
 			isa = PBXGroup;
 			children = (
 				5AE1F01E2A09628300103F08 /* OnboardingViewController.swift */,
+				5AF35C172A44BCCC00BC1C3A /* OnboardingPageViewController.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -766,6 +772,7 @@
 				5A84742D2A0E9A7500C2F93E /* CreateEditTrackerViewController.swift in Sources */,
 				5A8CD5202A20057B00A100BD /* InnerViewType.swift in Sources */,
 				5AE6BDE92A18D38F0068CB53 /* YPCell.swift in Sources */,
+				5AF35C182A44BCCC00BC1C3A /* OnboardingPageViewController.swift in Sources */,
 				5A1DFF012A3B847200AD63F3 /* TrackerCD.swift in Sources */,
 				5A45EA602A0CE96D003269D3 /* TrackersViewController.swift in Sources */,
 				5AE12A202A0A6B360054D782 /* AppCoordinator.swift in Sources */,
@@ -806,6 +813,7 @@
 				5AA5FA2E2A13CE4F0056633B /* UICollectionView+Extensions.swift in Sources */,
 				5AA5FA382A1439CE0056633B /* TrackerCell.swift in Sources */,
 				5A2837642A3E515A00513B91 /* CreateEditCategoryViewController.swift in Sources */,
+				5AF35C162A44B7EE00BC1C3A /* OnboardingPage.swift in Sources */,
 				5A1DFF032A3B847200AD63F3 /* TrackerCategoryCD.swift in Sources */,
 				5AA5FA322A1409420056633B /* TrackerColorCell.swift in Sources */,
 				5AE12A252A0B90390054D782 /* Theme+Colors.swift in Sources */,

--- a/YP-Tracker/App/Coordinators/AppCoordinator.swift
+++ b/YP-Tracker/App/Coordinators/AppCoordinator.swift
@@ -2,7 +2,7 @@ final class AppCoordinator: BaseCoordinator {
 	private let factory: ICoordinatorFactory
 	private let router: Router
 
-	private var isOnboarding = true
+	private var hadOnboarding = false
 
 	init(router: Router, factory: ICoordinatorFactory) {
 		self.router = router
@@ -10,7 +10,7 @@ final class AppCoordinator: BaseCoordinator {
 	}
 
 	override func start() {
-		if isOnboarding {
+		if hadOnboarding {
 			runMainFlow()
 		} else {
 			runOnboardingFlow()
@@ -23,7 +23,7 @@ private extension AppCoordinator {
 	func runOnboardingFlow() {
 		let coordinator = factory.makeOnboardingCoordinator(router: router)
 		coordinator.finishFlow = { [weak self, weak coordinator] in
-			self?.isOnboarding = true
+			self?.hadOnboarding = true
 			self?.start()
 			self?.removeDependency(coordinator)
 		}

--- a/YP-Tracker/App/Coordinators/CreateEditTrackerCoordinator.swift
+++ b/YP-Tracker/App/Coordinators/CreateEditTrackerCoordinator.swift
@@ -117,7 +117,7 @@ private extension CreateEditTrackerCoordinator {
 	enum Appearance {
 		static let titleHabitVC = "Новая привычка"
 		static let titleEventVC = "Новое нерегулярное событие"
-		static let titleCategoryVC = "Категории"
+		static let titleCategoryVC = "Категория"
 		static let titleScheduleVC = "Расписание"
 		static let titleAddCategoryVC = "Новая категория"
 	}

--- a/YP-Tracker/App/Coordinators/CreateEditTrackerCoordinator.swift
+++ b/YP-Tracker/App/Coordinators/CreateEditTrackerCoordinator.swift
@@ -41,7 +41,9 @@ private extension CreateEditTrackerCoordinator {
 		moduleInteractor.didSendEventClosure = { [weak self, weak module] event in
 			switch event {
 			case let .selectCategory(currentID):
-				self?.showSelectCategoryModule(
+				// Study MVVM
+				// self?.showSelectCategoryModule(
+				self?.showSelectCategoryModuleMVVM(
 					currentCategory: currentID,
 					router: module
 				)
@@ -79,6 +81,27 @@ private extension CreateEditTrackerCoordinator {
 				self?.onUpdateCategory?(id, title)
 			}
 			if case .addCategory = event {
+				self?.showAddCategoryModule(router: module)
+			}
+		}
+		module.title = Appearance.titleCategoryVC
+		router?.present(UINavigationController(rootViewController: module), animated: true)
+	}
+
+	func showSelectCategoryModuleMVVM(currentCategory: UUID?, router: UIViewController?) {
+		let (module, viewModel) = factory.makeCategoriesListModuleMVVM(
+			trackerAction: .selectCategory(currentCategory)
+		)
+
+		onUpdateCategories = { [weak viewModel] in
+			viewModel?.update()
+		}
+		viewModel.didSendEventClosure = { [weak self, weak module] event in
+			if case let .selectCategory(id, title) = event {
+				module?.dismiss(animated: true)
+				self?.onUpdateCategory?(id, title)
+			}
+			if case .showCreateEditCategory = event {
 				self?.showAddCategoryModule(router: module)
 			}
 		}

--- a/YP-Tracker/App/Coordinators/OnboardingCoordinator.swift
+++ b/YP-Tracker/App/Coordinators/OnboardingCoordinator.swift
@@ -21,11 +21,10 @@ final class OnboardingCoordinator: BaseCoordinator {
 // MARK: - show Modules
 private extension OnboardingCoordinator {
 	func showOnboardingModule() {
-		let module = factory.makeOnboardingModule()
-		let moduleVC = module as? OnboardingViewController
-		moduleVC?.didSendEventClosure = { [weak self] event in
+		let (module, moduleInteractor) = factory.makeOnboardingModule()
+		moduleInteractor.didSendEventClosure = { [weak self] event in
 			switch event {
-			case .start:
+			case .finishOnboarding:
 				self?.finishFlow?()
 			}
 		}

--- a/YP-Tracker/App/Di/Di+ModuleFactory.swift
+++ b/YP-Tracker/App/Di/Di+ModuleFactory.swift
@@ -4,7 +4,7 @@ import UIKit
 
 protocol IModuleFactory: AnyObject {
 	func makeStartModule() -> UIViewController
-	func makeOnboardingModule() -> UIViewController
+	func makeOnboardingModule() -> (UIViewController, IOnboardingInteractor)
 	func makeTabbarModule() -> UIViewController
 	func makeStatisticsModule() -> UIViewController
 	func makeTrackersModule() -> (UIViewController, ITrackersInteractor)
@@ -16,8 +16,15 @@ protocol IModuleFactory: AnyObject {
 }
 
 extension Di {
-	func makeOnboardingModule(dep: AllDependencies) -> UIViewController {
-		return OnboardingViewController()
+	func makeOnboardingModule(dep: AllDependencies) -> (UIViewController, IOnboardingInteractor) {
+		let interactor = OnboardingInteractor()
+		let pageViewController = makeOnboardingPageViewController()
+		let view = OnboardingViewController(
+			interactor: interactor,
+			pageViewController: pageViewController
+		)
+
+		return (view, interactor)
 	}
 
 	func makeCoreDataTrainerModule(dep: AllDependencies) -> UIViewController {
@@ -100,5 +107,16 @@ extension Di {
 		presenter.viewController = view
 
 		return (view, interactor)
+	}
+}
+
+private extension Di {
+	func makeOnboardingPageViewController() -> UIPageViewController {
+		var pages: [UIViewController] = []
+		for page in OnboardingPage.allCases {
+			pages.append(OnboardingPageViewController(page: page))
+		}
+
+		return PageViewController(viewControllers: pages)
 	}
 }

--- a/YP-Tracker/App/Di/Di+ModuleFactory.swift
+++ b/YP-Tracker/App/Di/Di+ModuleFactory.swift
@@ -13,6 +13,9 @@ protocol IModuleFactory: AnyObject {
 	func makeCreateEditTrackerModule(trackerAction: Tracker.Action) -> (UIViewController, ICreateEditTrackerInteractor)
 	func makeCreateEditCategoryModule(trackerAction: Tracker.Action) -> (UIViewController, ICreateEditCategoryInteractor)
 	func makeCoreDataTrainerModule() -> UIViewController
+
+	// Study MVVM
+	func makeCategoriesListModuleMVVM(trackerAction: Tracker.Action) -> (UIViewController, CategoriesListViewModel)
 }
 
 extension Di {
@@ -75,6 +78,19 @@ extension Di {
 		presenter.viewController = view
 
 		return (view, interactor)
+	}
+
+	func makeCategoriesListModuleMVVM(
+		dep: AllDependencies,
+		trackerAction: Tracker.Action
+	) -> (UIViewController, CategoriesListViewModel) {
+		let viewModel = DefaultCategoriesListViewModel(
+			dep: dep,
+			trackerAction: trackerAction
+		)
+		let view = SelectCategoryViewController(viewModel: viewModel)
+
+		return (view, viewModel)
 	}
 
 	func makeCreateEditTrackerModule(

--- a/YP-Tracker/App/Di/Di.swift
+++ b/YP-Tracker/App/Di/Di.swift
@@ -64,9 +64,9 @@ extension Di: IModuleFactory {
 	func makeStartModule() -> UIViewController {
 		// Вспомогательный метод, для отдельного запуска сцен
 		// при let isOnlyScene = true в SceneDelegate
-		makeCoreDataTrainerModule()
+		makeOnboardingModule().0
 	}
-	func makeOnboardingModule() -> UIViewController {
+	func makeOnboardingModule() -> (UIViewController, IOnboardingInteractor) {
 		makeOnboardingModule(dep: dependencies)
 	}
 	func makeTabbarModule() -> UIViewController {

--- a/YP-Tracker/App/Di/Di.swift
+++ b/YP-Tracker/App/Di/Di.swift
@@ -64,7 +64,10 @@ extension Di: IModuleFactory {
 	func makeStartModule() -> UIViewController {
 		// Вспомогательный метод, для отдельного запуска сцен
 		// при let isOnlyScene = true в SceneDelegate
-		makeOnboardingModule().0
+		// makeOnboardingModule().0
+		let view = makeCategoriesListModuleMVVM(trackerAction: .selectCategory(nil)).0
+		view.title = "Категория"
+		return UINavigationController(rootViewController: view)
 	}
 	func makeOnboardingModule() -> (UIViewController, IOnboardingInteractor) {
 		makeOnboardingModule(dep: dependencies)
@@ -80,6 +83,9 @@ extension Di: IModuleFactory {
 	}
 	func makeYPModule(trackerAction: Tracker.Action) -> (UIViewController, IYPInteractor) {
 		makeYPModule(dep: dependencies, trackerAction: trackerAction)
+	}
+	func makeCategoriesListModuleMVVM(trackerAction: Tracker.Action) -> (UIViewController, CategoriesListViewModel) {
+		makeCategoriesListModuleMVVM(dep: dependencies, trackerAction: trackerAction)
 	}
 	func makeSelectTypeTrackerModule() -> (UIViewController, ISelectTypeTrackerInteractor) {
 		makeSelectTypeTrackerModule(dep: dependencies)

--- a/YP-Tracker/App/Services/CategoriesManagerCD.swift
+++ b/YP-Tracker/App/Services/CategoriesManagerCD.swift
@@ -20,92 +20,6 @@ final class CategoriesManagerCD {
 	}
 }
 
-private extension CategoriesManagerCD {
-	func runRequest<T: NSManagedObject>(
-		_ request: NSFetchRequest<T>
-	) -> [T] {
-		var result: [T] = []
-		do {
-			result = try mainContext.fetch(request)
-		} catch let error as NSError {
-			let message = "При выполнении запроса Core Data произошла ошибка:"
-			print(message, error, error.userInfo)
-		}
-		return result
-	}
-
-	func findObjectByUUID<T: NSManagedObject>(
-		id: UUID,
-		key: String,
-		withRequest request: NSFetchRequest<T>
-	) -> T? {
-		request.predicate = NSPredicate(format: "\(key) == %@", id as CVarArg)
-		request.fetchLimit = 1
-		guard let object = runRequest(request).first else { return nil }
-		return object
-	}
-
-	func updateCreateTracker(
-		from tracker: Tracker,
-		withCategoryID categoryID: UUID
-	) {
-		guard let categoryCD = findObjectByUUID(
-			id: categoryID,
-			key: "categoryID",
-			withRequest: TrackerCategoryCD.fetchRequest()
-		) else { return }
-
-		let trackerCD: TrackerCD
-		if let foundTrackerCD = findObjectByUUID(
-			id: tracker.id,
-			key: "trackerID",
-			withRequest: TrackerCD.fetchRequest()
-		) {
-			trackerCD = foundTrackerCD
-		} else {
-			trackerCD = TrackerCD(context: mainContext)
-		}
-
-		trackerCD.trackerID = tracker.id
-		trackerCD.title = tracker.title
-		trackerCD.emoji = tracker.emoji
-		trackerCD.color = tracker.color
-		trackerCD.schedule = tracker.scheduleCD
-		trackerCD.trackerCategory = categoryCD
-		mainContext.saveContext()
-	}
-
-	func completeUncompletedTracker(
-		trackerID: UUID,
-		date: Date
-	) {
-		guard let trackerCD = findObjectByUUID(
-			id: trackerID,
-			key: "trackerID",
-			withRequest: TrackerCD.fetchRequest()
-		) else { return }
-
-		let dateString = Theme.dateFormatterCD.string(from: date)
-
-		let request = TrackerRecordCD.fetchRequest()
-		request.predicate = NSPredicate(
-			format: "trackerID == %@ && dateString == %@",
-			trackerID as CVarArg,
-			dateString
-		)
-
-		if let trackerRecordCD = runRequest(request).first {
-			mainContext.delete(trackerRecordCD)
-		} else {
-			let trackerRecordCD = TrackerRecordCD(context: mainContext)
-			trackerRecordCD.trackerID = trackerID
-			trackerRecordCD.dateString = dateString
-			trackerRecordCD.tracker = trackerCD
-		}
-		mainContext.saveContext()
-	}
-}
-
 // MARK: - ICategoriesManager
 
 extension CategoriesManagerCD: ICategoriesManager {
@@ -209,6 +123,92 @@ extension CategoriesManagerCD: ICategoriesManager {
 			trackerID: trackerID,
 			date: date
 		)
+	}
+}
+
+private extension CategoriesManagerCD {
+	func runRequest<T: NSManagedObject>(
+		_ request: NSFetchRequest<T>
+	) -> [T] {
+		var result: [T] = []
+		do {
+			result = try mainContext.fetch(request)
+		} catch let error as NSError {
+			let message = "При выполнении запроса Core Data произошла ошибка:"
+			print(message, error, error.userInfo)
+		}
+		return result
+	}
+
+	func findObjectByUUID<T: NSManagedObject>(
+		id: UUID,
+		key: String,
+		withRequest request: NSFetchRequest<T>
+	) -> T? {
+		request.predicate = NSPredicate(format: "\(key) == %@", id as CVarArg)
+		request.fetchLimit = 1
+		guard let object = runRequest(request).first else { return nil }
+		return object
+	}
+
+	func updateCreateTracker(
+		from tracker: Tracker,
+		withCategoryID categoryID: UUID
+	) {
+		guard let categoryCD = findObjectByUUID(
+			id: categoryID,
+			key: "categoryID",
+			withRequest: TrackerCategoryCD.fetchRequest()
+		) else { return }
+
+		let trackerCD: TrackerCD
+		if let foundTrackerCD = findObjectByUUID(
+			id: tracker.id,
+			key: "trackerID",
+			withRequest: TrackerCD.fetchRequest()
+		) {
+			trackerCD = foundTrackerCD
+		} else {
+			trackerCD = TrackerCD(context: mainContext)
+		}
+
+		trackerCD.trackerID = tracker.id
+		trackerCD.title = tracker.title
+		trackerCD.emoji = tracker.emoji
+		trackerCD.color = tracker.color
+		trackerCD.schedule = tracker.scheduleCD
+		trackerCD.trackerCategory = categoryCD
+		mainContext.saveContext()
+	}
+
+	func completeUncompletedTracker(
+		trackerID: UUID,
+		date: Date
+	) {
+		guard let trackerCD = findObjectByUUID(
+			id: trackerID,
+			key: "trackerID",
+			withRequest: TrackerCD.fetchRequest()
+		) else { return }
+
+		let dateString = Theme.dateFormatterCD.string(from: date)
+
+		let request = TrackerRecordCD.fetchRequest()
+		request.predicate = NSPredicate(
+			format: "trackerID == %@ && dateString == %@",
+			trackerID as CVarArg,
+			dateString
+		)
+
+		if let trackerRecordCD = runRequest(request).first {
+			mainContext.delete(trackerRecordCD)
+		} else {
+			let trackerRecordCD = TrackerRecordCD(context: mainContext)
+			trackerRecordCD.trackerID = trackerID
+			trackerRecordCD.dateString = dateString
+			trackerRecordCD.tracker = trackerCD
+		}
+		mainContext.saveContext()
 	}
 }
 

--- a/YP-Tracker/Library/OptionalViews/EmptyInputData.swift
+++ b/YP-Tracker/Library/OptionalViews/EmptyInputData.swift
@@ -14,6 +14,10 @@ extension EmptyInputData {
 		image: Theme.image(kind: .trackerStartPlaceholder),
 		message: Appearance.emptyTrackersListMessage
 	)
+	static let emptyStartCategories = EmptyInputData(
+		image: Theme.image(kind: .trackerStartPlaceholder),
+		message: Appearance.emptyCategoriesListMessage
+	)
 	static let emptyStatistics = EmptyInputData(
 		image: Theme.image(kind: .statsPlaceholder),
 		message: Appearance.emptyStatisticsListMessage
@@ -22,8 +26,9 @@ extension EmptyInputData {
 
 private extension EmptyInputData {
 	enum Appearance {
-		static let emptyTrackersListMessage = "Что будем отслеживать?"
 		static let emptySearchListMessage = "Ничего не найдено"
+		static let emptyTrackersListMessage = "Что будем отслеживать?"
+		static let emptyCategoriesListMessage = "Привычки и события можно\nобъединить по смыслу"
 		static let emptyStatisticsListMessage = "Анализировать пока нечего"
 	}
 }

--- a/YP-Tracker/Library/OptionalViews/EmptyView.swift
+++ b/YP-Tracker/Library/OptionalViews/EmptyView.swift
@@ -74,6 +74,8 @@ private extension EmptyView {
 		let label = UILabel()
 		label.textColor = Theme.color(usage: .main)
 		label.font = Theme.font(style: .caption1)
+		label.textAlignment = .center
+		label.numberOfLines = 0
 		return label
 	}
 }

--- a/YP-Tracker/Library/OptionalViews/EmptyView.swift
+++ b/YP-Tracker/Library/OptionalViews/EmptyView.swift
@@ -75,7 +75,7 @@ private extension EmptyView {
 		label.textColor = Theme.color(usage: .main)
 		label.font = Theme.font(style: .caption1)
 		label.textAlignment = .center
-		label.numberOfLines = 0
+		label.numberOfLines = .zero
 		return label
 	}
 }

--- a/YP-Tracker/Library/Utils/Observable.swift
+++ b/YP-Tracker/Library/Utils/Observable.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+final class Observable<Value> {
+
+	struct Observer<Value> {
+		weak var observer: AnyObject?
+		let block: (Value) -> Void
+	}
+
+	private var observers = [Observer<Value>]()
+
+	var value: Value {
+		didSet { notifyObservers() }
+	}
+
+	init(_ value: Value) {
+		self.value = value
+	}
+
+	func observe(on observer: AnyObject, observerBlock: @escaping (Value) -> Void) {
+		observers.append(Observer(observer: observer, block: observerBlock))
+		observerBlock(self.value)
+	}
+
+	func remove(observer: AnyObject) {
+		observers = observers.filter { $0.observer !== observer }
+	}
+
+	private func notifyObservers() {
+		for observer in observers {
+			observer.block(self.value)
+		}
+	}
+}

--- a/YP-Tracker/Models/OnboardingPage.swift
+++ b/YP-Tracker/Models/OnboardingPage.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+enum OnboardingPage: CaseIterable {
+	case blue
+	case red
+
+	// как вариант развития
+	var shouldShowSkipButton: Bool {
+		switch self {
+		case .blue, .red:
+			return true
+		}
+	}
+
+	var textValue: String {
+		switch self {
+		case .blue:
+			return Appearance.blueTextValue
+		case .red:
+			return Appearance.redTextValue
+		}
+	}
+
+	var imageValue: UIImage {
+		switch self {
+		case .blue:
+			return Theme.image(kind: .onboardingPage1)
+		case .red:
+			return Theme.image(kind: .onboardingPage2)
+		}
+	}
+
+	// TODO: - пока думаю о необходимости ввода индексов
+}
+
+private extension OnboardingPage {
+	enum Appearance {
+		static let blueTextValue = "Отслеживайте только /nто, что хотите"
+		static let redTextValue = "Даже если это /nне литры воды и йога"
+	}
+}

--- a/YP-Tracker/Models/OnboardingPage.swift
+++ b/YP-Tracker/Models/OnboardingPage.swift
@@ -4,14 +4,6 @@ enum OnboardingPage: CaseIterable {
 	case blue
 	case red
 
-	// как вариант развития
-	var shouldShowSkipButton: Bool {
-		switch self {
-		case .blue, .red:
-			return true
-		}
-	}
-
 	var textValue: String {
 		switch self {
 		case .blue:
@@ -29,13 +21,11 @@ enum OnboardingPage: CaseIterable {
 			return Theme.image(kind: .onboardingPage2)
 		}
 	}
-
-	// TODO: - пока думаю о необходимости ввода индексов
 }
 
 private extension OnboardingPage {
 	enum Appearance {
-		static let blueTextValue = "Отслеживайте только /nто, что хотите"
-		static let redTextValue = "Даже если это /nне литры воды и йога"
+		static let blueTextValue = "Отслеживайте только\nто, что хотите"
+		static let redTextValue = "Даже если это\nне литры воды и йога"
 	}
 }

--- a/YP-Tracker/Modules/CreateEditTracker/Cells/TrackerColorCell.swift
+++ b/YP-Tracker/Modules/CreateEditTracker/Cells/TrackerColorCell.swift
@@ -3,8 +3,8 @@ import UIKit
 final class TrackerColorCell: UICollectionViewCell {
 	// MARK: - UI Elements
 
-	private lazy var background = makeBagroundView()
-	private lazy var colorView = makeColorView()
+	fileprivate lazy var background = makeBagroundView()
+	fileprivate lazy var colorView = makeColorView()
 
 	// MARK: - Inits
 
@@ -32,18 +32,18 @@ final class TrackerColorCell: UICollectionViewCell {
 
 		colorView.backgroundColor = .clear
 	}
+}
 
-	// MARK: - Data model for cell
+// MARK: - Data model for cell
 
-	struct TrackerColorCellModel {
-		let colorString: String
-		let isSelected: Bool
-	}
+struct TrackerColorCellModel {
+	let colorString: String
+	let isSelected: Bool
 }
 
 // MARK: - ICellViewModel
 
-extension TrackerColorCell.TrackerColorCellModel: ICellViewModel {
+extension TrackerColorCellModel: ICellViewModel {
 	func setup(cell: TrackerColorCell) {
 		let color = UIColor(hex: colorString)
 		cell.colorView.backgroundColor = color
@@ -93,11 +93,11 @@ struct TrackerColorCell_Previews: PreviewProvider {
 	static var previews: some View {
 
 		let view1 = TrackerColorCell()
-		let model = TrackerColorCell.TrackerColorCellModel(colorString: TrackerColor.green.rawValue, isSelected: false)
+		let model = TrackerColorCellModel(colorString: TrackerColor.green.rawValue, isSelected: false)
 		model.setup(cell: view1)
 
 		let view2 = TrackerColorCell()
-		let model2 = TrackerColorCell.TrackerColorCellModel(colorString: TrackerColor.green.rawValue, isSelected: true)
+		let model2 = TrackerColorCellModel(colorString: TrackerColor.green.rawValue, isSelected: true)
 		model2.setup(cell: view2)
 
 		let view3 = TrackerColorCell()

--- a/YP-Tracker/Modules/CreateEditTracker/Cells/TrackerEmojiCell.swift
+++ b/YP-Tracker/Modules/CreateEditTracker/Cells/TrackerEmojiCell.swift
@@ -3,8 +3,8 @@ import UIKit
 final class TrackerEmojiCell: UICollectionViewCell {
 	// MARK: - UI Elements
 
-	private lazy var background = makeBagroundView()
-	private lazy var emojiLabel = makeEmojiLabel()
+	fileprivate lazy var background = makeBagroundView()
+	fileprivate lazy var emojiLabel = makeEmojiLabel()
 
 	// MARK: - Inits
 
@@ -32,18 +32,18 @@ final class TrackerEmojiCell: UICollectionViewCell {
 
 		emojiLabel.text = nil
 	}
+}
 
-	// MARK: - Data model for cell
+// MARK: - Data model for cell
 
-	struct TrackerEmojiCellModel {
-		let emoji: String
-		let isSelected: Bool
-	}
+struct TrackerEmojiCellModel {
+	let emoji: String
+	let isSelected: Bool
 }
 
 // MARK: - ICellViewModel
 
-extension TrackerEmojiCell.TrackerEmojiCellModel: ICellViewModel {
+extension TrackerEmojiCellModel: ICellViewModel {
 	func setup(cell: TrackerEmojiCell) {
 		cell.emojiLabel.text = emoji
 		if isSelected {
@@ -91,11 +91,11 @@ struct TrackerEmojiCell_Previews: PreviewProvider {
 	static var previews: some View {
 
 		let view1 = TrackerEmojiCell()
-		let model1 = TrackerEmojiCell.TrackerEmojiCellModel(emoji: "❤️", isSelected: false)
+		let model1 = TrackerEmojiCellModel(emoji: "❤️", isSelected: false)
 		model1.setup(cell: view1)
 
 		let view2 = TrackerEmojiCell()
-		let model2 = TrackerEmojiCell.TrackerEmojiCellModel(emoji: "❤️", isSelected: true)
+		let model2 = TrackerEmojiCellModel(emoji: "❤️", isSelected: true)
 		model2.setup(cell: view2)
 
 		let view3 = TrackerEmojiCell()

--- a/YP-Tracker/Modules/CreateEditTracker/CreateEditTrackerModels.swift
+++ b/YP-Tracker/Modules/CreateEditTracker/CreateEditTrackerModels.swift
@@ -1,16 +1,6 @@
 import Foundation
 
 enum CreateEditTrackerModels {
-	struct YPCellModel {
-		let type: InnerViewType
-		let title: String
-		let description: String
-		let hasDivider: Bool
-		let outCorner: [CellCorner]
-		let isSelected: Bool
-		let event: (() -> Void)?
-	}
-
 	struct SimpleCellModel {
 		let title: String
 		let isSelected: Bool
@@ -73,7 +63,6 @@ enum CreateEditTrackerModels {
 				}
 			}
 		}
-
 		case showAllComponents(hasSchedule: Bool, title: String, components: [Section], isSaveEnabled: Bool)
 		case showNewSection(section: Int, items: Section, isSaveEnabled: Bool)
 		case showSaveEnabled(isSaveEnabled: Bool)

--- a/YP-Tracker/Modules/CreateEditTracker/CreateEditTrackerViewController.swift
+++ b/YP-Tracker/Modules/CreateEditTracker/CreateEditTrackerViewController.swift
@@ -149,21 +149,19 @@ extension CreateEditTrackerViewController: UICollectionViewDataSource {
 		let section = dataSource[indexPath.section]
 		switch section {
 		case let .category(category):
-			let model = makeCellModel(item: category)
-			return collectionView.dequeueReusableCell(withModel: model, for: indexPath)
+			return collectionView.dequeueReusableCell(withModel: category, for: indexPath)
 		case let .schedule(schedule):
-			let model = makeCellModel(item: schedule)
-			return collectionView.dequeueReusableCell(withModel: model, for: indexPath)
+			return collectionView.dequeueReusableCell(withModel: schedule, for: indexPath)
 		case let .emoji(emojis):
 			let emoji = emojis[indexPath.row]
-			let model = TrackerEmojiCell.TrackerEmojiCellModel(
+			let model = TrackerEmojiCellModel(
 				emoji: emoji.title,
 				isSelected: emoji.isSelected
 			)
 			return collectionView.dequeueReusableCell(withModel: model, for: indexPath)
 		case let .color(colors):
 			let color = colors[indexPath.row]
-			let model = TrackerColorCell.TrackerColorCellModel(
+			let model = TrackerColorCellModel(
 				colorString: color.title,
 				isSelected: color.isSelected
 			)
@@ -177,25 +175,13 @@ extension CreateEditTrackerViewController: UICollectionViewDataSource {
 		at indexPath: IndexPath
 	) -> UICollectionReusableView {
 		let section = dataSource[indexPath.section]
-		let model = HeaderSupplementaryView.HeaderSupplementaryViewModel(
+		let model = HeaderSupplementaryViewModel(
 			title: section.description
 		)
 		return collectionView.dequeueReusableSupplementaryView(
 			kind: kind,
 			withModel: model,
 			for: indexPath
-		)
-	}
-
-	private func makeCellModel(item: CreateEditTrackerModels.YPCellModel) -> YPCell.YPCellModel {
-		return YPCell.YPCellModel(
-			type: item.type,
-			title: item.title,
-			description: item.description,
-			hasDivider: item.hasDivider,
-			outCorner: item.outCorner,
-			isSelected: item.isSelected,
-			event: item.event
 		)
 	}
 }
@@ -266,7 +252,10 @@ private extension CreateEditTrackerViewController {
 			]
 		}
 
-		view.addSubview(scrollView)
+		[
+			UIView(frame: .zero),
+			scrollView
+		].forEach { view.addSubview($0) }
 		scrollView.makeEqualToSuperviewToSafeArea()
 	}
 
@@ -374,12 +363,12 @@ private extension CreateEditTrackerViewController {
 		)
 
 		collectionView.register(models: [
-			YPCell.YPCellModel.self,
-			TrackerEmojiCell.TrackerEmojiCellModel.self,
-			TrackerColorCell.TrackerColorCellModel.self
+			YPCellModel.self,
+			TrackerEmojiCellModel.self,
+			TrackerColorCellModel.self
 		])
 		collectionView.registerSupplementaryView(models: [
-			(HeaderSupplementaryView.HeaderSupplementaryViewModel.self, UICollectionView.elementKindSectionHeader)
+			(HeaderSupplementaryViewModel.self, UICollectionView.elementKindSectionHeader)
 		])
 
 		collectionView.dataSource = self

--- a/YP-Tracker/Modules/Onboarding/OnboardingInteractor.swift
+++ b/YP-Tracker/Modules/Onboarding/OnboardingInteractor.swift
@@ -1,0 +1,17 @@
+enum EventOnboardingInteractor {
+	case finishOnboarding
+}
+
+protocol IOnboardingInteractor: AnyObject {
+	func didUserDo(request: EventOnboardingInteractor)
+
+	var didSendEventClosure: ((EventOnboardingInteractor) -> Void)? { get set }
+}
+
+final class OnboardingInteractor: IOnboardingInteractor {
+	var didSendEventClosure: ((EventOnboardingInteractor) -> Void)?
+
+	func didUserDo(request: EventOnboardingInteractor) {
+		didSendEventClosure?(request)
+	}
+}

--- a/YP-Tracker/Modules/Onboarding/OnboardingPageViewController.swift
+++ b/YP-Tracker/Modules/Onboarding/OnboardingPageViewController.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+final class OnboardingPageViewController: UIViewController {
+	private let page: OnboardingPage
+
+	private lazy var imageView: UIImageView = makeImageView()
+	private lazy var textLabel: UILabel = makeLabel()
+
+	// MARK: - Inits
+
+	init(page: OnboardingPage) {
+		self.page = page
+		super.init(nibName: nil, bundle: nil)
+	}
+
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	deinit {
+		print("OnboardingPageViewController deinit")
+	}
+
+	// MARK: - Lifecycle
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		setConstraints()
+	}
+}
+
+// MARK: - UI
+private extension OnboardingPageViewController {
+	func setConstraints() {
+		[
+			imageView,
+			textLabel
+		].forEach { view.addSubview($0) }
+
+		imageView.makeEqualToSuperview()
+		// TODO: - в фигме не совсем по центру
+		textLabel.makeEqualToSuperviewCenterToSafeArea()
+	}
+}
+
+// MARK: - UI make
+private extension OnboardingPageViewController {
+	func makeImageView() -> UIImageView {
+		let imageView = UIImageView(image: page.imageValue)
+		imageView.contentMode = .scaleAspectFill
+		return imageView
+	}
+	func makeLabel() -> UILabel {
+		let label = UILabel()
+		label.text = page.textValue
+		label.textColor = Theme.color(usage: .main)
+		label.font = Theme.font(style: .title1)
+		label.textAlignment = .center
+		label.numberOfLines = 0
+		return label
+	}
+}

--- a/YP-Tracker/Modules/Onboarding/OnboardingViewController.swift
+++ b/YP-Tracker/Modules/Onboarding/OnboardingViewController.swift
@@ -1,11 +1,22 @@
 import UIKit
 
 final class OnboardingViewController: UIViewController {
-	var didSendEventClosure: ((OnboardingViewController.Event) -> Void)?
+	private let interactor: IOnboardingInteractor
+	private let pageViewController: UIPageViewController
 
-	private lazy var startButton: UIButton = makeStartButton()
+	private lazy var actionButton: UIButton = makeActionButton()
 
 	// MARK: - Inits
+
+	init(interactor: IOnboardingInteractor, pageViewController: UIPageViewController) {
+		self.interactor = interactor
+		self.pageViewController = pageViewController
+		super.init(nibName: nil, bundle: nil)
+	}
+
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
 
 	deinit {
 		print("OnboardingViewController deinit")
@@ -21,57 +32,57 @@ final class OnboardingViewController: UIViewController {
 	}
 }
 
-// MARK: - Event
-extension OnboardingViewController {
-	enum Event {
-		case start
-	}
-}
-
-// MARK: - Actions
-private extension OnboardingViewController {
-	@objc func didTapStartButton(_ sender: Any) {
-		didSendEventClosure?(.start)
-	}
-}
-
 // MARK: - UI
 private extension OnboardingViewController {
 	func setup() {
-		startButton.addTarget(self, action: #selector(didTapStartButton(_:)), for: .touchUpInside)
+		addChild(pageViewController)
+		view.addSubview(pageViewController.view)
+		pageViewController.didMove(toParent: self)
 	}
 	func applyStyle() {
 		view.backgroundColor = Theme.color(usage: .white)
 	}
 	func setConstraints() {
-		let stackView = UIStackView()
-		stackView.axis = .vertical
-		stackView.spacing = Theme.spacing(usage: .standard)
-
 		[
-			startButton
-		].forEach { item in
-			stackView.addArrangedSubview(item)
-		}
+			actionButton
+		].forEach { view.addSubview($0) }
 
-		view.addSubview(stackView)
-		stackView.makeEqualToSuperviewCenter()
-
-		startButton.makeConstraints { make in
-			make.size(.init(width: Appearance.buttonSize.width, height: Appearance.buttonSize.height))
+		actionButton.makeConstraints { make in
+			[
+				make.leadingAnchor.constraint(
+					equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+					constant: Theme.spacing(usage: .constant20)
+				),
+				make.trailingAnchor.constraint(
+					equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+					constant: -Theme.spacing(usage: .constant20)
+				),
+				make.bottomAnchor.constraint(
+					equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+					constant: -Appearance.buttonBottomAnchorConstant
+				),
+				make.heightAnchor.constraint(
+					equalToConstant: Theme.size(kind: .buttonHeight)
+				)
+			]
 		}
 	}
 }
 
 // MARK: - UI make
 private extension OnboardingViewController {
-	func makeStartButton() -> UIButton {
+	func makeActionButton() -> UIButton {
 		let button = UIButton()
-		button.setTitle(Appearance.buttonText, for: .normal)
+
+		button.setTitle(Appearance.buttonTitle, for: .normal)
+		button.setTitleColor(Theme.color(usage: .white), for: .normal)
 		button.titleLabel?.font = Theme.font(style: .callout)
-		button.backgroundColor = Theme.color(usage: .accent)
-		button.setTitleColor(Theme.color(usage: .attention), for: .normal)
+		button.backgroundColor = Theme.color(usage: .black)
 		button.layer.cornerRadius = Theme.size(kind: .cornerRadius)
+
+		button.event = { [weak self] in
+			self?.interactor.didUserDo(request: .finishOnboarding)
+		}
 
 		return button
 	}
@@ -80,7 +91,7 @@ private extension OnboardingViewController {
 // MARK: - Appearance
 private extension OnboardingViewController {
 	enum Appearance {
-		static let buttonText = "Onboarding"
-		static let buttonSize: CGSize = .init(width: 200, height: 50)
+		static let buttonTitle = "Вот это технологии!"
+		static let buttonBottomAnchorConstant: CGFloat = 50
 	}
 }

--- a/YP-Tracker/Modules/Onboarding/PageViewController/OnboardingPageViewController.swift
+++ b/YP-Tracker/Modules/Onboarding/PageViewController/OnboardingPageViewController.swift
@@ -1,9 +1,13 @@
 import UIKit
 
-final class OnboardingPageViewController: UIViewController {
+protocol ViewControllerWithImageView: UIViewController {
+	var imageView: UIImageView { get set }
+}
+
+final class OnboardingPageViewController: UIViewController, ViewControllerWithImageView {
 	private let page: OnboardingPage
 
-	private lazy var imageView: UIImageView = makeImageView()
+	lazy var imageView: UIImageView = makeImageView()
 	private lazy var textLabel: UILabel = makeLabel()
 
 	// MARK: - Inits
@@ -38,8 +42,14 @@ private extension OnboardingPageViewController {
 		].forEach { view.addSubview($0) }
 
 		imageView.makeEqualToSuperview()
-		// TODO: - в фигме не совсем по центру
-		textLabel.makeEqualToSuperviewCenterToSafeArea()
+		textLabel.makeEqualToSuperviewCenter(
+			insets: .init(
+				top: Appearance.centerIndent,
+				left: .zero,
+				bottom: .zero,
+				right: .zero
+			)
+		)
 	}
 }
 
@@ -56,7 +66,14 @@ private extension OnboardingPageViewController {
 		label.textColor = Theme.color(usage: .main)
 		label.font = Theme.font(style: .title1)
 		label.textAlignment = .center
-		label.numberOfLines = 0
+		label.numberOfLines = .zero
 		return label
+	}
+}
+
+// MARK: - Appearance
+private extension OnboardingPageViewController {
+	enum Appearance {
+		static let centerIndent = UIScreen.main.bounds.height / 100 * 7.88
 	}
 }

--- a/YP-Tracker/Modules/Onboarding/PageViewController/PageViewController.swift
+++ b/YP-Tracker/Modules/Onboarding/PageViewController/PageViewController.swift
@@ -1,0 +1,217 @@
+import UIKit
+
+final class PageViewController: UIPageViewController {
+
+	private var leftPageScroll: Int?
+	private var currentPageScroll: Int?
+	private var rightPageScroll: Int?
+
+	private var pages: [UIViewController] = []
+
+	var currentIndex: Int {
+		if
+			let first = self.viewControllers?.first,
+			let index = pages.firstIndex(of: first) {
+			return index
+		}
+		return .zero
+	}
+
+	// MARK: - Inits
+
+	init(viewControllers: [UIViewController]? = nil) {
+		super.init(
+			transitionStyle: .scroll,
+			navigationOrientation: .horizontal,
+			options: [:]
+		)
+		if let viewControllers = viewControllers {
+			pages = viewControllers
+		}
+		setup()
+	}
+
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	deinit {
+		print("PageViewController deinit")
+	}
+
+	// MARK: - Life cycle
+
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+		for view in self.view.subviews {
+			if view is UIScrollView {
+				view.frame = UIScreen.main.bounds
+			} else if view is UIPageControl {
+				view.backgroundColor = .clear
+				view.frame.origin.y = self.view.bounds.size.height - view.bounds.height - Appearance.pageControlYMinusConstant
+
+				(view as? UIPageControl)?.currentPageIndicatorTintColor = Theme.color(usage: .black)
+				(view as? UIPageControl)?.pageIndicatorTintColor = Theme.color(usage: .gray)
+			}
+		}
+	}
+}
+
+private extension PageViewController {
+	func setup() {
+		guard
+			let scrollview = view.subviews.first(
+				where: { $0 is UIScrollView }
+			) as? UIScrollView else { return }
+
+		// делаем PageViewController делегатом прокрутки
+		scrollview.delegate = self
+
+		dataSource = self
+		delegate = self
+
+		if pages.isEmpty {
+			createPages()
+		}
+
+		if let firstViewController = pages.first {
+			setViewControllers(
+				[firstViewController],
+				direction: .forward,
+				animated: true,
+				completion: nil
+			)
+		}
+	}
+
+	func createPages() {
+		for page in OnboardingPage.allCases {
+			pages.append(OnboardingPageViewController(page: page))
+		}
+	}
+}
+
+// MARK: - UIPageViewControllerDataSource
+
+extension PageViewController: UIPageViewControllerDataSource {
+	func pageViewController(
+		_ pageViewController: UIPageViewController,
+		viewControllerBefore viewController: UIViewController
+	) -> UIViewController? {
+		guard let currentPageIndex = pages.firstIndex(of: viewController) else {
+			return nil
+		}
+
+		let previousIndex = currentPageIndex - 1
+
+		guard
+			previousIndex >= 0,
+			pages.count > previousIndex
+		else {
+			return nil
+		}
+
+		return pages[previousIndex]
+	}
+
+	func pageViewController(
+		_ pageViewController: UIPageViewController,
+		viewControllerAfter viewController: UIViewController
+	) -> UIViewController? {
+		guard let currentPageIndex = pages.firstIndex(of: viewController) else {
+			return nil
+		}
+
+		let nextIndex = currentPageIndex + 1
+
+		// зациклим вправо
+		if pages.count == nextIndex {
+			return pages.first
+		}
+
+		guard pages.count > nextIndex else {
+			return nil
+		}
+
+		return pages[nextIndex]
+	}
+
+	// MARK: - UIPageControl
+
+	func presentationCount(for pageViewController: UIPageViewController) -> Int {
+		return pages.count
+	}
+
+	func presentationIndex(for pageViewController: UIPageViewController) -> Int {
+		return currentIndex
+	}
+}
+
+// MARK: UIPageViewControllerDelegate
+
+extension PageViewController: UIPageViewControllerDelegate {}
+
+// MARK: UIScrollViewDelegate
+
+extension PageViewController: UIScrollViewDelegate {
+
+	// позволяет узнать какая страница является текущей, предыдушей и следующей
+	func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+		setVarsForScroll()
+	}
+
+	private func setVarsForScroll() {
+		leftPageScroll = mod((currentIndex - 1), pages.count)
+		currentPageScroll = currentIndex
+		rightPageScroll = mod((currentIndex + 1), pages.count)
+	}
+
+	private func mod(_ new: Int, _ all: Int) -> Int {
+		precondition(all > 0, "modulus must be positive")
+		let result = new % all
+		return result >= 0 ? result : result + all
+	}
+
+	// вся магия здесь
+	func scrollViewDidScroll(_ scrollView: UIScrollView) {
+		let maximumHorizontalOffset: CGFloat = scrollView.contentSize.width - scrollView.frame.width
+		let currentHorizontalOffset: CGFloat = scrollView.contentOffset.x
+		let percentageHorizontalOffset: CGFloat = currentHorizontalOffset / maximumHorizontalOffset
+
+		guard let currentPageScroll = currentPageScroll else { return }
+
+		if percentageHorizontalOffset < 0.5 {
+			guard let leftPageScroll = leftPageScroll else { return }
+			if let prevVC = pages[leftPageScroll] as? ViewControllerWithImageView {
+				prevVC.imageView.transform = CGAffineTransform(
+					scaleX: (1 - percentageHorizontalOffset),
+					y: (1 - percentageHorizontalOffset)
+				)
+			}
+		}
+
+		if percentageHorizontalOffset > 0.5 {
+			guard let rightPageScroll = rightPageScroll else { return }
+			if let prevVC = pages[currentPageScroll] as? ViewControllerWithImageView {
+				prevVC.imageView.transform = CGAffineTransform(
+					scaleX: abs(0.75 - percentageHorizontalOffset) / 0.25,
+					y: abs(0.75 - percentageHorizontalOffset) / 0.25
+				)
+			}
+
+			if let nextVC = pages[rightPageScroll] as? ViewControllerWithImageView {
+				nextVC.imageView.transform = CGAffineTransform(
+					scaleX: percentageHorizontalOffset,
+					y: percentageHorizontalOffset
+				)
+			}
+		}
+	}
+}
+
+// MARK: - Appearance
+private extension PageViewController {
+	enum Appearance {
+		static let pageControlYMinusConstant: CGFloat = 168
+	}
+}

--- a/YP-Tracker/Modules/SelectCategoryMVVM/SelectCategoryViewController.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/SelectCategoryViewController.swift
@@ -65,20 +65,8 @@ extension SelectCategoryViewController: UICollectionViewDataSource {
 		_ collectionView: UICollectionView,
 		cellForItemAt indexPath: IndexPath
 	) -> UICollectionViewCell {
-		collectionView.dequeueReusableCell(withModel: getModelAtIndex(indexPath.row), for: indexPath)
-	}
-
-	private func getModelAtIndex(_ index: Int) -> YPCell.YPCellModel {
-		let item = viewModel.itemAtIndex(index)
-		return YPCell.YPCellModel(
-			type: item.type,
-			title: item.title,
-			description: item.description,
-			hasDivider: item.hasDivider,
-			outCorner: item.outCorner,
-			isSelected: item.isSelected,
-			event: item.event
-		)
+		let model = viewModel.cellModelAtIndex(indexPath.row)
+		return collectionView.dequeueReusableCell(withModel: model, for: indexPath)
 	}
 }
 
@@ -162,7 +150,7 @@ private extension SelectCategoryViewController {
 		)
 
 		collectionView.register(models: [
-			YPCell.YPCellModel.self
+			YPCellModel.self
 		])
 
 		collectionView.dataSource = self

--- a/YP-Tracker/Modules/SelectCategoryMVVM/SelectCategoryViewController.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/SelectCategoryViewController.swift
@@ -1,0 +1,259 @@
+import UIKit
+
+final class SelectCategoryViewController: UIViewController {
+	private var viewModel: CategoriesListViewModel
+
+	private lazy var collectionView: UICollectionView = makeCollectionView()
+	private lazy var emptyView = makeEmptyView()
+	private lazy var actionButton: UIButton = makeActionButton()
+
+	// MARK: - Inits
+
+	init(viewModel: CategoriesListViewModel) {
+		self.viewModel = viewModel
+		super.init(nibName: nil, bundle: nil)
+	}
+
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	deinit {
+		print("SelectCategoryViewController deinit")
+	}
+
+	// MARK: - Lifecycle
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		setup()
+		applyStyle()
+		setConstraints()
+
+		bind(to: viewModel)
+		viewModel.viewIsReady()
+	}
+}
+
+// MARK: - Bind
+
+private extension SelectCategoryViewController {
+	func bind(to viewModel: CategoriesListViewModel) {
+		viewModel.items.observe(on: self) { [weak self] _ in
+			self?.updateItems()
+		}
+	}
+
+	func updateItems() {
+		collectionView.reloadData()
+		emptyView.isHidden = !viewModel.isEmpty
+	}
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension SelectCategoryViewController: UICollectionViewDataSource {
+	func collectionView(
+		_ collectionView: UICollectionView,
+		numberOfItemsInSection section: Int
+	) -> Int {
+		viewModel.numberOfItems
+	}
+
+	func collectionView(
+		_ collectionView: UICollectionView,
+		cellForItemAt indexPath: IndexPath
+	) -> UICollectionViewCell {
+		collectionView.dequeueReusableCell(withModel: getModelAtIndex(indexPath.row), for: indexPath)
+	}
+
+	private func getModelAtIndex(_ index: Int) -> YPCell.YPCellModel {
+		let item = viewModel.itemAtIndex(index)
+		return YPCell.YPCellModel(
+			type: item.type,
+			title: item.title,
+			description: item.description,
+			hasDivider: item.hasDivider,
+			outCorner: item.outCorner,
+			isSelected: item.isSelected,
+			event: item.event
+		)
+	}
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension SelectCategoryViewController: UICollectionViewDelegate {
+	func collectionView(
+		_ collectionView: UICollectionView,
+		didSelectItemAt indexPath: IndexPath
+	) {
+		collectionView.deselectItem(at: indexPath, animated: true)
+		viewModel.didSelectItemAtIndex(indexPath.row)
+	}
+}
+
+// MARK: - UI
+private extension SelectCategoryViewController {
+	func setup() {
+		navigationController?.navigationBar.prefersLargeTitles = false
+		navigationController?.navigationBar.standardAppearance.titleTextAttributes = [
+			NSAttributedString.Key.foregroundColor: Theme.color(usage: .black),
+			NSAttributedString.Key.font: Theme.font(style: .callout)
+		]
+	}
+
+	func applyStyle() {
+		view.backgroundColor = Theme.color(usage: .white)
+	}
+
+	func setConstraints() {
+		let stack = UIStackView()
+		stack.axis = .vertical
+		stack.spacing = Theme.spacing(usage: .standard)
+		stack.alignment = .center
+		[
+			collectionView,
+			actionButton
+		].forEach { stack.addArrangedSubview($0) }
+
+		collectionView.makeConstraints { make in
+			[
+				make.leadingAnchor.constraint(equalTo: stack.leadingAnchor),
+				make.trailingAnchor.constraint(equalTo: stack.trailingAnchor)
+			]
+		}
+
+		actionButton.makeConstraints { make in
+			[
+				make.leadingAnchor.constraint(equalTo: stack.leadingAnchor, constant: Theme.spacing(usage: .standardHalf)),
+				make.trailingAnchor.constraint(equalTo: stack.trailingAnchor, constant: -Theme.spacing(usage: .standardHalf)),
+				make.heightAnchor.constraint(equalToConstant: Theme.size(kind: .buttonHeight))
+			]
+		}
+
+		[
+			UIView(frame: .zero),
+			stack,
+			emptyView
+		].forEach { view.addSubview($0) }
+
+		stack.makeEqualToSuperviewToSafeArea(
+			insets: .init(
+				top: Theme.spacing(usage: .standard3),
+				left: Theme.spacing(usage: .standard2),
+				bottom: Theme.spacing(usage: .standard3),
+				right: Theme.spacing(usage: .standard2)
+			)
+		)
+		emptyView.makeEqualToSuperviewCenterToSafeArea()
+	}
+}
+
+// MARK: - UI make
+private extension SelectCategoryViewController {
+	func makeCollectionView() -> UICollectionView {
+		let layout = createLayout()
+
+		let collectionView = UICollectionView(
+			frame: .zero,
+			collectionViewLayout: layout
+		)
+
+		collectionView.register(models: [
+			YPCell.YPCellModel.self
+		])
+
+		collectionView.dataSource = self
+		collectionView.delegate = self
+
+		collectionView.backgroundColor = .clear
+		collectionView.bounces = false // чтобы не скролилось никуда
+
+		collectionView.layer.cornerRadius = Theme.size(kind: .cornerRadius)
+		collectionView.clipsToBounds = true
+
+		return collectionView
+	}
+	func makeEmptyView() -> EmptyView {
+		let view = EmptyView()
+		view.update(with: EmptyInputData.emptyStartCategories)
+		view.isHidden = true
+
+		return view
+	}
+	func makeActionButton() -> UIButton {
+		let button = UIButton()
+
+		button.setTitle(Appearance.actionButtonTitle, for: .normal)
+		button.setTitleColor(Theme.color(usage: .white), for: .normal)
+		button.titleLabel?.font = Theme.font(style: .callout)
+		button.backgroundColor = Theme.color(usage: .black)
+		button.layer.cornerRadius = Theme.size(kind: .cornerRadius)
+
+		button.event = { [weak self] in
+			self?.viewModel.didTapAddCategoryButton()
+		}
+
+		return button
+	}
+}
+
+// MARK: - CompositionalLayout
+private extension SelectCategoryViewController {
+	func createLayout() -> UICollectionViewCompositionalLayout {
+		UICollectionViewCompositionalLayout { [weak self] _, _ in
+			guard let self = self else { return nil }
+			return self.createItemLayout()
+		}
+	}
+
+	func createLayoutSection(
+		group: NSCollectionLayoutGroup,
+		behavior: UICollectionLayoutSectionOrthogonalScrollingBehavior,
+		interGroupSpacing: CGFloat,
+		supplementaryItem: [NSCollectionLayoutBoundarySupplementaryItem]
+	) -> NSCollectionLayoutSection {
+		let section = NSCollectionLayoutSection(group: group)
+		section.orthogonalScrollingBehavior = behavior
+		section.interGroupSpacing = interGroupSpacing
+		section.boundarySupplementaryItems = supplementaryItem
+
+		return section
+	}
+
+	func createItemLayout() -> NSCollectionLayoutSection {
+		let itemSize = NSCollectionLayoutSize(
+			widthDimension: .fractionalWidth(1.0),
+			heightDimension: .fractionalHeight(1.0)
+		)
+		let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+		let groupSize = NSCollectionLayoutSize(
+			widthDimension: .fractionalWidth(1.0),
+			heightDimension: .absolute(Theme.size(kind: .textFieldHeight)) // высота
+		)
+		let group = NSCollectionLayoutGroup.horizontal(
+			layoutSize: groupSize,
+			subitem: item,
+			count: 1 // кол-во элементов в группе
+		)
+
+		let section = createLayoutSection(
+			group: group, // минимально let section = NSCollectionLayoutSection(group: group)
+			behavior: .none, // важно для скроллинга
+			interGroupSpacing: .zero, // по вертикали между группами
+			supplementaryItem: [] // нет доп вьюх
+		)
+
+		return section
+	}
+}
+
+// MARK: - Appearance
+private extension SelectCategoryViewController {
+	enum Appearance {
+		static let actionButtonTitle = "Добавить категорию"
+	}
+}

--- a/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListItemViewModel.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListItemViewModel.swift
@@ -1,36 +1,14 @@
 struct CategoriesListItemViewModel {
-	let type: InnerViewType = .checkmarkType
 	let title: String
-	let description = ""
-	let hasDivider: Bool
-	let outCorner: [CellCorner]
 	let isSelected: Bool
-	let event: (() -> Void)?
 }
 
 extension CategoriesListItemViewModel {
 	init(
 		category: TrackerCategory,
-		first: Bool,
-		last: Bool,
-		isSelected: Bool,
-		event: (() -> Void)?
+		isSelected: Bool
 	) {
 		self.title = category.title
-		self.hasDivider = !last
-
-		switch (first, last) {
-		case (true, true):
-			self.outCorner = [.all]
-		case (true, false):
-			self.outCorner = [.top]
-		case (false, true):
-			self.outCorner = [.bottom]
-		default:
-			self.outCorner = []
-		}
-
 		self.isSelected = isSelected
-		self.event = event
 	}
 }

--- a/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListItemViewModel.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListItemViewModel.swift
@@ -1,0 +1,36 @@
+struct CategoriesListItemViewModel {
+	let type: InnerViewType = .checkmarkType
+	let title: String
+	let description = ""
+	let hasDivider: Bool
+	let outCorner: [CellCorner]
+	let isSelected: Bool
+	let event: (() -> Void)?
+}
+
+extension CategoriesListItemViewModel {
+	init(
+		category: TrackerCategory,
+		first: Bool,
+		last: Bool,
+		isSelected: Bool,
+		event: (() -> Void)?
+	) {
+		self.title = category.title
+		self.hasDivider = !last
+
+		switch (first, last) {
+		case (true, true):
+			self.outCorner = [.all]
+		case (true, false):
+			self.outCorner = [.top]
+		case (false, true):
+			self.outCorner = [.bottom]
+		default:
+			self.outCorner = []
+		}
+
+		self.isSelected = isSelected
+		self.event = event
+	}
+}

--- a/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListViewModel.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListViewModel.swift
@@ -31,16 +31,16 @@ final class DefaultCategoriesListViewModel: CategoriesListViewModel {
 	// MARK: - INPUT
 	var didSendEventClosure: ((CategoriesListEvents) -> Void)?
 
+	// MARK: - OUTPUT
+	var items: Observable<[CategoriesListItemViewModel]> = Observable([])
+	var numberOfItems: Int { items.value.count }
+	var isEmpty: Bool { items.value.isEmpty }
+
 	private let categoriesProvider: ICategoriesProvider
 	private let trackerAction: Tracker.Action
 
 	private var selectedItemIndex: Int?
 	private var categories: [TrackerCategory] = []
-
-	// MARK: - OUTPUT
-	var items: Observable<[CategoriesListItemViewModel]> = Observable([])
-	var numberOfItems: Int { items.value.count }
-	var isEmpty: Bool { items.value.isEmpty }
 
 	// MARK: - Inits
 

--- a/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListViewModel.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListViewModel.swift
@@ -19,7 +19,7 @@ protocol CategoriesListViewModelOutput: AnyObject {
 	var numberOfItems: Int { get }
 	var isEmpty: Bool { get }
 
-	func itemAtIndex(_ index: Int) -> CategoriesListItemViewModel
+	func cellModelAtIndex(_ index: Int) -> YPCellModel
 }
 
 typealias CategoriesListViewModel = (
@@ -56,8 +56,34 @@ final class DefaultCategoriesListViewModel: CategoriesListViewModel {
 // MARK: - OUTPUT
 
 extension DefaultCategoriesListViewModel {
-	func itemAtIndex(_ index: Int) -> CategoriesListItemViewModel {
-		items.value[index]
+	func cellModelAtIndex(_ index: Int) -> YPCellModel {
+		let item = items.value[index]
+
+		let all = categories.count
+		let first = index == 0
+		let last = index == all - 1
+
+		let outCorner: [CellCorner]
+		switch (first, last) {
+		case (true, true):
+			outCorner = [.all]
+		case (true, false):
+			outCorner = [.top]
+		case (false, true):
+			outCorner = [.bottom]
+		default:
+			outCorner = []
+		}
+
+		return YPCellModel(
+			type: .checkmarkType,
+			title: item.title,
+			description: "",
+			hasDivider: !last,
+			outCorner: outCorner,
+			isSelected: item.isSelected,
+			event: nil
+		)
 	}
 }
 
@@ -116,13 +142,9 @@ extension DefaultCategoriesListViewModel {
 
 private extension DefaultCategoriesListViewModel {
 	func createItem(index: Int, isSelected: Bool) -> CategoriesListItemViewModel {
-		let all = categories.count
-		return CategoriesListItemViewModel(
+		CategoriesListItemViewModel(
 			category: categories[index],
-			first: index == 0,
-			last: index == all - 1,
-			isSelected: isSelected,
-			event: nil
+			isSelected: isSelected
 		)
 	}
 }

--- a/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListViewModel.swift
+++ b/YP-Tracker/Modules/SelectCategoryMVVM/ViewModel/CategoriesListViewModel.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+enum CategoriesListEvents {
+	case showCreateEditCategory
+	case selectCategory(UUID, String)
+}
+
+protocol CategoriesListViewModelInput: AnyObject {
+	var didSendEventClosure: ((CategoriesListEvents) -> Void)? { get set }
+
+	func viewIsReady()
+	func update()
+	func didSelectItemAtIndex(_ index: Int)
+	func didTapAddCategoryButton()
+}
+
+protocol CategoriesListViewModelOutput: AnyObject {
+	var items: Observable<[CategoriesListItemViewModel]> { get }
+	var numberOfItems: Int { get }
+	var isEmpty: Bool { get }
+
+	func itemAtIndex(_ index: Int) -> CategoriesListItemViewModel
+}
+
+typealias CategoriesListViewModel = (
+	CategoriesListViewModelInput &
+	CategoriesListViewModelOutput
+)
+
+final class DefaultCategoriesListViewModel: CategoriesListViewModel {
+	// MARK: - INPUT
+	var didSendEventClosure: ((CategoriesListEvents) -> Void)?
+
+	private let categoriesProvider: ICategoriesProvider
+	private let trackerAction: Tracker.Action
+
+	private var selectedItemIndex: Int?
+	private var categories: [TrackerCategory] = []
+
+	// MARK: - OUTPUT
+	var items: Observable<[CategoriesListItemViewModel]> = Observable([])
+	var numberOfItems: Int { items.value.count }
+	var isEmpty: Bool { items.value.isEmpty }
+
+	// MARK: - Inits
+
+	init(
+		dep: IYPModuleDependency,
+		trackerAction: Tracker.Action
+	) {
+		self.trackerAction = trackerAction
+		self.categoriesProvider = dep.categoriesProvider
+	}
+}
+
+// MARK: - OUTPUT
+
+extension DefaultCategoriesListViewModel {
+	func itemAtIndex(_ index: Int) -> CategoriesListItemViewModel {
+		items.value[index]
+	}
+}
+
+// MARK: - INPUT. View event methods
+
+extension DefaultCategoriesListViewModel {
+	func viewIsReady() {
+		if case let .selectCategory(categoryID) = trackerAction {
+			categories = categoriesProvider.getCategories()
+
+			items.value = categories.enumerated().map { keyValue in
+				if keyValue.element.id == categoryID {
+					selectedItemIndex = keyValue.offset
+				}
+				return createItem(
+					index: keyValue.offset,
+					isSelected: keyValue.element.id == categoryID
+				)
+			}
+		}
+	}
+
+	func update() {
+		viewIsReady()
+	}
+
+	func didSelectItemAtIndex(_ index: Int) {
+		let category = categories[index]
+		if
+			let selectedItemIndex = selectedItemIndex,
+			selectedItemIndex != index
+		{
+			items.value[selectedItemIndex] = createItem(
+				index: selectedItemIndex,
+				isSelected: false
+			)
+			items.value[index] = createItem(
+				index: index,
+				isSelected: true
+			)
+			self.selectedItemIndex = index
+		} else {
+			selectedItemIndex = index
+			items.value[index] = createItem(
+				index: index,
+				isSelected: true
+			)
+		}
+		didSendEventClosure?(.selectCategory(category.id, category.title))
+	}
+
+	func didTapAddCategoryButton() {
+		didSendEventClosure?(.showCreateEditCategory)
+	}
+}
+
+private extension DefaultCategoriesListViewModel {
+	func createItem(index: Int, isSelected: Bool) -> CategoriesListItemViewModel {
+		let all = categories.count
+		return CategoriesListItemViewModel(
+			category: categories[index],
+			first: index == 0,
+			last: index == all - 1,
+			isSelected: isSelected,
+			event: nil
+		)
+	}
+}

--- a/YP-Tracker/Modules/SelectTypeTracker/SelectTypeTrackerViewController.swift
+++ b/YP-Tracker/Modules/SelectTypeTracker/SelectTypeTrackerViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 final class SelectTypeTrackerViewController: UIViewController {
-	let interactor: ISelectTypeTrackerInteractor
+	private let interactor: ISelectTypeTrackerInteractor
 
 	private lazy var habitButton: UIButton = makeButtonByTrackerType(.habit)
 	private lazy var eventButton: UIButton = makeButtonByTrackerType(.event)

--- a/YP-Tracker/Modules/Trackers/Cells/HeaderSupplementaryView.swift
+++ b/YP-Tracker/Modules/Trackers/Cells/HeaderSupplementaryView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 final class HeaderSupplementaryView: UICollectionReusableView {
 	// MARK: - UI Elements
-	private lazy var headerLabel = makeHeaderLabel()
+	fileprivate lazy var headerLabel = makeHeaderLabel()
 
 	// MARK: - Inits
 
@@ -23,17 +23,17 @@ final class HeaderSupplementaryView: UICollectionReusableView {
 
 		headerLabel.text = nil
 	}
+}
 
-	// MARK: - Data model for cell
+// MARK: - Data model for cell
 
-	struct HeaderSupplementaryViewModel {
-		let title: String
-	}
+struct HeaderSupplementaryViewModel {
+	let title: String
 }
 
 // MARK: - ICellViewModel
 
-extension HeaderSupplementaryView.HeaderSupplementaryViewModel: ICellViewModel {
+extension HeaderSupplementaryViewModel: ICellViewModel {
 	func setup(cell: HeaderSupplementaryView) {
 		cell.headerLabel.text = title
 	}

--- a/YP-Tracker/Modules/Trackers/Cells/TrackerCell.swift
+++ b/YP-Tracker/Modules/Trackers/Cells/TrackerCell.swift
@@ -3,11 +3,11 @@ import UIKit
 final class TrackerCell: UICollectionViewCell {
 	// MARK: - UI Elements
 
-	private lazy var colorBackgroudnView = makeColorBackgroundView()
-	private lazy var emojiLabel = makeEmojiLabel()
-	private lazy var titleLabel = makeTitleLabel()
-	private lazy var dayLabel = makeDayLabel()
-	private lazy var completeButton = makeCompleteButton()
+	fileprivate lazy var colorBackgroudnView = makeColorBackgroundView()
+	fileprivate lazy var emojiLabel = makeEmojiLabel()
+	fileprivate lazy var titleLabel = makeTitleLabel()
+	fileprivate lazy var dayLabel = makeDayLabel()
+	fileprivate lazy var completeButton = makeCompleteButton()
 
 	// MARK: - Inits
 
@@ -31,23 +31,23 @@ final class TrackerCell: UICollectionViewCell {
 		dayLabel.text = ""
 		completeButton.event = nil
 	}
+}
 
-	// MARK: - Data model for cell
+// MARK: - Data model for cell
 
-	struct TrackerCellModel {
-		let colorString: String
-		let emoji: String
-		let title: String
-		let dayTime: String
-		let isCompleted: Bool
-		let isButtonEnabled: Bool
-		let event: (() -> Void)?
-	}
+struct TrackerCellModel {
+	let colorString: String
+	let emoji: String
+	let title: String
+	let dayTime: String
+	let isCompleted: Bool
+	let isButtonEnabled: Bool
+	let event: (() -> Void)?
 }
 
 // MARK: - ICellViewModel
 
-extension TrackerCell.TrackerCellModel: ICellViewModel {
+extension TrackerCellModel: ICellViewModel {
 	func setup(cell: TrackerCell) {
 		let color = UIColor(hex: colorString)
 
@@ -192,7 +192,7 @@ struct TrackerCell_Previews: PreviewProvider {
 	static var previews: some View {
 
 		let view1 = TrackerCell()
-		let model1 = TrackerCell.TrackerCellModel(
+		let model1 = TrackerCellModel(
 			colorString: TrackerColor.blue.rawValue,
 			emoji: "🏓",
 			title: "Учить iOS много много учить еще учить",
@@ -204,7 +204,7 @@ struct TrackerCell_Previews: PreviewProvider {
 		model1.setup(cell: view1)
 
 		let view2 = TrackerCell()
-		let model2 = TrackerCell.TrackerCellModel(
+		let model2 = TrackerCellModel(
 			colorString: TrackerColor.orange.rawValue,
 			emoji: "😇",
 			title: "Бабушка прислала открытку в вотсапе",
@@ -216,7 +216,7 @@ struct TrackerCell_Previews: PreviewProvider {
 		model2.setup(cell: view2)
 
 		let view3 = TrackerCell()
-		let model3 = TrackerCell.TrackerCellModel(
+		let model3 = TrackerCellModel(
 			colorString: TrackerColor.green.rawValue,
 			emoji: "😇",
 			title: "Хорошее настроение",

--- a/YP-Tracker/Modules/Trackers/TrackersInteractor.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersInteractor.swift
@@ -108,6 +108,6 @@ private extension TrackersInteractor {
 			sectionsWithTrackers.append(sectionWithTrackers)
 		}
 
-		presenter.present(data: .update(sectionsWithTrackers, conditions))
+		presenter.present(data: .update(sectionsWithTrackers, conditions, self))
 	}
 }

--- a/YP-Tracker/Modules/Trackers/TrackersModels.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersModels.swift
@@ -16,21 +16,13 @@ enum TrackersModels {
 			// swiftlint:disable:next large_tuple
 			let trackers: [(tracker: Tracker, completed: Bool, allTimes: Int)]
 		}
-		case update([SectionWithTrackers], TrackerConditions)
+		case update([SectionWithTrackers], TrackerConditions, ITrackersInteractor?)
 	}
 
 	enum ViewModel {
-		struct TrackerModel {
-			let colorString: String
-			let emoji: String
-			let title: String
-			let dayTime: String
-			let isCompleted: Bool
-			let isActionEnabled: Bool
-		}
 		struct Section {
-			let title: String
-			let trackers: [TrackerModel]
+			let header: HeaderSupplementaryViewModel
+			let trackers: [TrackerCellModel]
 		}
 
 		case update([Section], TrackerConditions)

--- a/YP-Tracker/Modules/Trackers/TrackersPresenter.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersPresenter.swift
@@ -9,27 +9,30 @@ final class TrackersPresenter: ITrackersPresenter {
 	weak var viewController: ITrackersViewController?
 
 	typealias TrackerSection = TrackersModels.ViewModel.Section
-	typealias TrackerModel = TrackersModels.ViewModel.TrackerModel
 
 	func present(data: TrackersModels.Response) {
 
 		let viewData: TrackersModels.ViewModel
 
 		switch data {
-		case let .update(categories, conditions):
+		case let .update(categories, conditions, interactor):
+			weak var interactor = interactor
 			let isActionEnabled = checkIsActionEnabled(date: conditions.date)
 			var sections: [TrackerSection] = []
-			for category in categories {
+			for (index, category) in categories.enumerated() {
 				let section = TrackerSection(
-					title: category.sectionName,
-					trackers: category.trackers.map({ tracker, completed, allTimes in
-						TrackerModel(
-							colorString: tracker.color,
-							emoji: tracker.emoji,
-							title: tracker.title,
-							dayTime: "\(allTimes) дн./дней",
-							isCompleted: completed,
-							isActionEnabled: isActionEnabled
+					header: HeaderSupplementaryViewModel(title: category.sectionName),
+					trackers: category.trackers
+						.enumerated()
+						.map({ key, val in
+						TrackerCellModel(
+							colorString: val.tracker.color,
+							emoji: val.tracker.emoji,
+							title: val.tracker.title,
+							dayTime: "\(val.allTimes) дн./дней",
+							isCompleted: val.completed,
+							isButtonEnabled: isActionEnabled,
+							event: { interactor?.didUserDo(request: .completeUncompleteTracker(index, key)) }
 						)
 					})
 				)

--- a/YP-Tracker/Modules/Trackers/TrackersViewController.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersViewController.swift
@@ -42,6 +42,7 @@ final class TrackersViewController: UIViewController {
 	}
 
 	// MARK: - Lifecycle
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
@@ -173,6 +174,7 @@ private extension TrackersViewController {
 	}
 	func setConstraints() {
 		[
+			UIView(frame: .zero), // сделать навбар непрокручиваемым
 			collectionView,
 			emptyView,
 			filtersButton

--- a/YP-Tracker/Modules/Trackers/TrackersViewController.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersViewController.swift
@@ -109,23 +109,7 @@ extension TrackersViewController: UICollectionViewDataSource {
 		cellForItemAt indexPath: IndexPath
 	) -> UICollectionViewCell {
 
-		let tracker = dataSource[indexPath.section].trackers[indexPath.row]
-		let model = TrackerCell.TrackerCellModel(
-			colorString: tracker.colorString,
-			emoji: tracker.emoji,
-			title: tracker.title,
-			dayTime: tracker.dayTime,
-			isCompleted: tracker.isCompleted,
-			isButtonEnabled: tracker.isActionEnabled,
-			event: { [weak self] in
-				self?.interactor.didUserDo(
-					request: .completeUncompleteTracker(
-						indexPath.section,
-						indexPath.row
-					)
-				)
-			}
-		)
+		let model = dataSource[indexPath.section].trackers[indexPath.row]
 		return collectionView.dequeueReusableCell(withModel: model, for: indexPath)
 	}
 
@@ -135,10 +119,7 @@ extension TrackersViewController: UICollectionViewDataSource {
 		at indexPath: IndexPath
 	) -> UICollectionReusableView {
 
-		let section = dataSource[indexPath.section]
-		let model = HeaderSupplementaryView.HeaderSupplementaryViewModel(
-			title: section.title
-		)
+		let model = dataSource[indexPath.section].header
 		return collectionView.dequeueReusableSupplementaryView(
 			kind: kind,
 			withModel: model,
@@ -274,10 +255,10 @@ private extension TrackersViewController {
 		)
 
 		collectionView.register(models: [
-			TrackerCell.TrackerCellModel.self
+			TrackerCellModel.self
 		])
 		collectionView.registerSupplementaryView(models: [
-			(HeaderSupplementaryView.HeaderSupplementaryViewModel.self, UICollectionView.elementKindSectionHeader)
+			(HeaderSupplementaryViewModel.self, UICollectionView.elementKindSectionHeader)
 		])
 
 		collectionView.dataSource = self

--- a/YP-Tracker/Modules/Trackers/TrackersViewController.swift
+++ b/YP-Tracker/Modules/Trackers/TrackersViewController.swift
@@ -42,7 +42,7 @@ final class TrackersViewController: UIViewController {
 	}
 
 	// MARK: - Lifecycle
-	
+
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
@@ -178,9 +178,7 @@ private extension TrackersViewController {
 			collectionView,
 			emptyView,
 			filtersButton
-		].forEach { item in
-			view.addSubview(item)
-		}
+		].forEach { view.addSubview($0) }
 
 		collectionView.makeEqualToSuperviewToSafeArea()
 		emptyView.makeEqualToSuperviewCenterToSafeArea()

--- a/YP-Tracker/Modules/YPModule/Cell/YPCell.swift
+++ b/YP-Tracker/Modules/YPModule/Cell/YPCell.swift
@@ -3,12 +3,12 @@ import UIKit
 final class YPCell: UICollectionViewCell {
 	// MARK: - UI Elements
 
-	private lazy var titleLabel = makeTitleLabel()
-	private lazy var descriptionLabel = makeDescriptionLabel()
-	private lazy var dividerView = makeDividerView()
+	fileprivate lazy var titleLabel = makeTitleLabel()
+	fileprivate lazy var descriptionLabel = makeDescriptionLabel()
+	fileprivate lazy var dividerView = makeDividerView()
 
-	private var innerView = UIView()
-	private var event: (() -> Void)?
+	fileprivate var innerView = UIView()
+	fileprivate var event: (() -> Void)?
 
 	// MARK: - Inits
 
@@ -35,23 +35,23 @@ final class YPCell: UICollectionViewCell {
 			view.removeFromSuperview()
 		}
 	}
+}
 
-	// MARK: - Data model for cell
+// MARK: - Data model for cell
 
-	struct YPCellModel {
-		let type: InnerViewType
-		let title: String
-		let description: String
-		let hasDivider: Bool
-		let outCorner: [CellCorner]
-		let isSelected: Bool
-		let event: (() -> Void)?
-	}
+struct YPCellModel {
+	let type: InnerViewType
+	let title: String
+	let description: String
+	let hasDivider: Bool
+	let outCorner: [CellCorner]
+	let isSelected: Bool
+	let event: (() -> Void)?
 }
 
 // MARK: - ICellViewModel
 
-extension YPCell.YPCellModel: ICellViewModel {
+extension YPCellModel: ICellViewModel {
 	func setup(cell: YPCell) {
 		cell.titleLabel.text = title
 		cell.descriptionLabel.text = description
@@ -194,7 +194,7 @@ struct YPCell_Previews: PreviewProvider {
 	static var previews: some View {
 
 		let viewSwitch = YPCell()
-		let modelSwitch = YPCell.YPCellModel(
+		let modelSwitch = YPCellModel(
 			type: .switchType,
 			title: "Label",
 			description: "Описание",
@@ -206,7 +206,7 @@ struct YPCell_Previews: PreviewProvider {
 		modelSwitch.setup(cell: viewSwitch)
 
 		let viewSwitch2 = YPCell()
-		let modelSwitch2 = YPCell.YPCellModel(
+		let modelSwitch2 = YPCellModel(
 			type: .switchType,
 			title: "Label",
 			description: "Описание",
@@ -218,7 +218,7 @@ struct YPCell_Previews: PreviewProvider {
 		modelSwitch2.setup(cell: viewSwitch2)
 
 		let viewChevron = YPCell()
-		let modelChevron = YPCell.YPCellModel(
+		let modelChevron = YPCellModel(
 			type: .chevronType,
 			title: "Label",
 			description: "Описание",
@@ -230,7 +230,7 @@ struct YPCell_Previews: PreviewProvider {
 		modelChevron.setup(cell: viewChevron)
 
 		let viewChevron2 = YPCell()
-		let modelChevron2 = YPCell.YPCellModel(
+		let modelChevron2 = YPCellModel(
 			type: .chevronType,
 			title: "Label",
 			description: "",
@@ -242,7 +242,7 @@ struct YPCell_Previews: PreviewProvider {
 		modelChevron2.setup(cell: viewChevron2)
 
 		let viewCheckmark = YPCell()
-		let modelCheckmark = YPCell.YPCellModel(
+		let modelCheckmark = YPCellModel(
 			type: .checkmarkType,
 			title: "Label",
 			description: "Описание",
@@ -254,7 +254,7 @@ struct YPCell_Previews: PreviewProvider {
 		modelCheckmark.setup(cell: viewCheckmark)
 
 		let viewCheckmark2 = YPCell()
-		let modelCheckmark2 = YPCell.YPCellModel(
+		let modelCheckmark2 = YPCellModel(
 			type: .checkmarkType,
 			title: "Label",
 			description: "Описание",

--- a/YP-Tracker/Modules/YPModule/YPModels.swift
+++ b/YP-Tracker/Modules/YPModule/YPModels.swift
@@ -1,15 +1,5 @@
 import Foundation
 enum YPModels {
-	struct YPCellModel {
-		let type: InnerViewType
-		let title: String
-		let description: String
-		let hasDivider: Bool
-		let outCorner: [CellCorner]
-		let isSelected: Bool
-		let event: (() -> Void)?
-	}
-
 	enum Request {
 		case selectItemAtIndex(_ index: Int)
 		case tapActionButton

--- a/YP-Tracker/Modules/YPModule/YPPresenter.swift
+++ b/YP-Tracker/Modules/YPModule/YPPresenter.swift
@@ -103,7 +103,7 @@ private extension YPPresenter {
 			)
 		}
 
-		return .showSchedule(
+		return .showCategories(
 			.init(
 				dataSource: dataSource,
 				titleButtonAction: Appearance.addCategoryButtonTitle

--- a/YP-Tracker/Modules/YPModule/YPPresenter.swift
+++ b/YP-Tracker/Modules/YPModule/YPPresenter.swift
@@ -32,12 +32,12 @@ private extension YPPresenter {
 		let all = array.count
 		var next = 1
 
-		let dataSource: [YPModels.YPCellModel] = array.map { item in
+		let dataSource: [YPCellModel] = array.map { item in
 			let (hasDivider, outCorner) = getDecor(all: all, next: next)
 			let isSelected = item == current
 
 			next += 1
-			return YPModels.YPCellModel(
+			return YPCellModel(
 				type: .checkmarkType,
 				title: item.description,
 				description: "",
@@ -59,12 +59,12 @@ private extension YPPresenter {
 		let all = array.count
 		var next = 1
 
-		let dataSource: [YPModels.YPCellModel] = array.map { item in
+		let dataSource: [YPCellModel] = array.map { item in
 			let (hasDivider, outCorner) = getDecor(all: all, next: next)
 			let isSelected = current[next] ?? false
 
 			next += 1
-			return YPModels.YPCellModel(
+			return YPCellModel(
 				type: .switchType,
 				title: item,
 				description: "",
@@ -87,12 +87,12 @@ private extension YPPresenter {
 		let all = array.count
 		var next = 1
 
-		let dataSource: [YPModels.YPCellModel] = array.map { item in
+		let dataSource: [YPCellModel] = array.map { item in
 			let (hasDivider, outCorner) = getDecor(all: all, next: next)
 			let isSelected = item.id == current
 
 			next += 1
-			return YPModels.YPCellModel(
+			return YPCellModel(
 				type: .checkmarkType,
 				title: item.title,
 				description: "",

--- a/YP-Tracker/Modules/YPModule/YPViewController.swift
+++ b/YP-Tracker/Modules/YPModule/YPViewController.swift
@@ -10,6 +10,7 @@ final class YPViewController: UIViewController {
 	private var dataSource: [YPModels.YPCellModel] = []
 
 	private lazy var collectionView: UICollectionView = makeCollectionView()
+	private lazy var emptyView = makeEmptyView()
 	private lazy var actionButton: UIButton = makeActionButton()
 
 	// MARK: - Inits
@@ -53,6 +54,10 @@ extension YPViewController: IYPViewController {
 			actionButton.isHidden = viewData.titleButtonAction.isEmpty
 			dataSource = viewData.dataSource
 			collectionView.reloadData()
+		}
+
+		if case .showCategories = viewModel {
+			emptyView.isHidden = !dataSource.isEmpty
 		}
 	}
 }
@@ -146,7 +151,11 @@ private extension YPViewController {
 			]
 		}
 
-		view.addSubview(stack)
+		[
+			stack,
+			emptyView
+		].forEach { view.addSubview($0) }
+
 		stack.makeEqualToSuperviewToSafeArea(
 			insets: .init(
 				top: Theme.spacing(usage: .standard3),
@@ -155,6 +164,7 @@ private extension YPViewController {
 				right: Theme.spacing(usage: .standard2)
 			)
 		)
+		emptyView.makeEqualToSuperviewCenterToSafeArea()
 	}
 }
 
@@ -182,6 +192,13 @@ private extension YPViewController {
 		collectionView.clipsToBounds = true
 
 		return collectionView
+	}
+	func makeEmptyView() -> EmptyView {
+		let view = EmptyView()
+		view.update(with: EmptyInputData.emptyStartCategories)
+		view.isHidden = true
+
+		return view
 	}
 	func makeActionButton() -> UIButton {
 		let button = UIButton()

--- a/YP-Tracker/Modules/YPModule/YPViewController.swift
+++ b/YP-Tracker/Modules/YPModule/YPViewController.swift
@@ -7,7 +7,7 @@ protocol IYPViewController: AnyObject {
 
 final class YPViewController: UIViewController {
 	private let interactor: IYPInteractor
-	private var dataSource: [YPModels.YPCellModel] = []
+	private var dataSource: [YPCellModel] = []
 
 	private lazy var collectionView: UICollectionView = makeCollectionView()
 	private lazy var emptyView = makeEmptyView()
@@ -77,16 +77,7 @@ extension YPViewController: UICollectionViewDataSource {
 		cellForItemAt indexPath: IndexPath
 	) -> UICollectionViewCell {
 
-		let item = dataSource[indexPath.row]
-		let model = YPCell.YPCellModel(
-			type: item.type,
-			title: item.title,
-			description: item.description,
-			hasDivider: item.hasDivider,
-			outCorner: item.outCorner,
-			isSelected: item.isSelected,
-			event: item.event
-		)
+		let model = dataSource[indexPath.row]
 		return collectionView.dequeueReusableCell(withModel: model, for: indexPath)
 	}
 }
@@ -143,6 +134,7 @@ private extension YPViewController {
 		}
 
 		[
+			UIView(frame: .zero),
 			stack,
 			emptyView
 		].forEach { view.addSubview($0) }
@@ -170,7 +162,7 @@ private extension YPViewController {
 		)
 
 		collectionView.register(models: [
-			YPCell.YPCellModel.self
+			YPCellModel.self
 		])
 
 		collectionView.dataSource = self

--- a/YP-Tracker/Modules/YPModule/YPViewController.swift
+++ b/YP-Tracker/Modules/YPModule/YPViewController.swift
@@ -62,15 +62,6 @@ extension YPViewController: IYPViewController {
 	}
 }
 
-// MARK: - Event
-extension YPViewController {
-	enum Event {
-		case didSelectFilter(TrackerFilter)
-		case didSelectSchedule([Int: Bool])
-		case didSelectCategory(UUID)
-	}
-}
-
 // MARK: - UICollectionViewDataSource
 
 extension YPViewController: UICollectionViewDataSource {


### PR DESCRIPTION
## Описание к работе
- минимум по MVVM: сделал только экран с выбором категории
- так как основная архитектура Clean Swift, то все модули сохранил, где идет вызов создания модуля с MVVM, старый код закомментировал
### по чек листу #9
* п. 1.1 - реализовано отдельным сервисом CategoriesProvider. CтОит ли сервис дробить по useCases?
* п. 1.3-4 - у меня CollectionView
* выщеплял экран SelectCategoryViewController из YPViewController, который был заточен сразу под несколько выборов: фильтры, расписание, категории, ячейку использовал туже, которая также для всех случаев.

**Буду рад любым предложениям по улучшению.**